### PR TITLE
ci: add Pulumi preview + gated deploy GitHub Actions

### DIFF
--- a/.github/workflows/pulumi-deploy.yml
+++ b/.github/workflows/pulumi-deploy.yml
@@ -50,6 +50,17 @@ jobs:
           sudo zerotier-cli peers || true
           exit 1
 
+      - name: Write kubeconfig
+        env:
+          KUBECONFIG_CONTENT: ${{ secrets.KUBECONFIG }}
+        run: |
+          # The Pulumi program's k8s provider uses the ambient kubeconfig to reach
+          # the k3s API (https://10.144.180.10:6443, over ZeroTier).
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$KUBECONFIG_CONTENT" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
+
       - name: Pulumi up
         uses: pulumi/actions@v7
         env:

--- a/.github/workflows/pulumi-deploy.yml
+++ b/.github/workflows/pulumi-deploy.yml
@@ -1,0 +1,52 @@
+name: pulumi-deploy
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: pulumi-deploy       # global: never overlap applies
+  cancel-in-progress: false  # let an in-flight apply finish
+
+permissions:
+  contents: read
+
+jobs:
+  up:
+    runs-on: ubuntu-latest
+    environment: production   # <- requires manual approval (see setup)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'
+          cache: npm
+
+      - run: npm ci
+
+      - name: Join ZeroTier
+        uses: zerotier/github-action@v1.0.1
+        with:
+          network_id: ${{ secrets.ZEROTIER_NETWORK_ID }}
+          auth_token: ${{ secrets.ZEROTIER_CENTRAL_TOKEN }}
+
+      - name: Wait for state backend over ZeroTier
+        run: |
+          for i in $(seq 1 30); do
+            ping -c1 -W1 10.144.180.10 >/dev/null 2>&1 && { echo ok; exit 0; }
+            echo "waiting... ($i)"; sleep 2
+          done
+          echo "backend unreachable"; exit 1
+
+      - name: Pulumi up
+        uses: pulumi/actions@v7
+        env:
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS: '1'
+        with:
+          command: up
+          stack-name: dev
+          cloud-url: ${{ secrets.PULUMI_BACKEND_URL }}
+          diff: true
+          comment-on-summary: true

--- a/.github/workflows/pulumi-deploy.yml
+++ b/.github/workflows/pulumi-deploy.yml
@@ -33,11 +33,22 @@ jobs:
 
       - name: Wait for state backend over ZeroTier
         run: |
-          for i in $(seq 1 30); do
-            ping -c1 -W1 10.144.180.10 >/dev/null 2>&1 && { echo ok; exit 0; }
-            echo "waiting... ($i)"; sleep 2
+          echo "ZeroTier networks:"; sudo zerotier-cli listnetworks || true
+          # Gate on the real dependency (TCP 5432), not ICMP. A fresh runner may
+          # need a while to establish a ZeroTier path to the NAT'd homelab peer.
+          for i in $(seq 1 60); do
+            if timeout 3 bash -c 'cat < /dev/null > /dev/tcp/10.144.180.10/5432' 2>/dev/null; then
+              echo "state backend 10.144.180.10:5432 reachable after ${i} tries"; exit 0
+            fi
+            if [ $((i % 10)) -eq 0 ]; then
+              echo "still waiting ($i); ZeroTier peers:"; sudo zerotier-cli peers || true
+            fi
+            sleep 3
           done
-          echo "backend unreachable"; exit 1
+          echo "::error::state backend 10.144.180.10:5432 unreachable over ZeroTier after 180s"
+          sudo zerotier-cli listnetworks || true
+          sudo zerotier-cli peers || true
+          exit 1
 
       - name: Pulumi up
         uses: pulumi/actions@v7

--- a/.github/workflows/pulumi-preview.yml
+++ b/.github/workflows/pulumi-preview.yml
@@ -33,13 +33,22 @@ jobs:
 
       - name: Wait for state backend over ZeroTier
         run: |
-          for i in $(seq 1 30); do
-            if ping -c1 -W1 10.144.180.10 >/dev/null 2>&1; then
-              echo "backend reachable"; exit 0
+          echo "ZeroTier networks:"; sudo zerotier-cli listnetworks || true
+          # Gate on the real dependency (TCP 5432), not ICMP. A fresh runner may
+          # need a while to establish a ZeroTier path to the NAT'd homelab peer.
+          for i in $(seq 1 60); do
+            if timeout 3 bash -c 'cat < /dev/null > /dev/tcp/10.144.180.10/5432' 2>/dev/null; then
+              echo "state backend 10.144.180.10:5432 reachable after ${i} tries"; exit 0
             fi
-            echo "waiting for ZeroTier route... ($i)"; sleep 2
+            if [ $((i % 10)) -eq 0 ]; then
+              echo "still waiting ($i); ZeroTier peers:"; sudo zerotier-cli peers || true
+            fi
+            sleep 3
           done
-          echo "state backend 10.144.180.10 unreachable over ZeroTier"; exit 1
+          echo "::error::state backend 10.144.180.10:5432 unreachable over ZeroTier after 180s"
+          sudo zerotier-cli listnetworks || true
+          sudo zerotier-cli peers || true
+          exit 1
 
       - name: Pulumi preview
         uses: pulumi/actions@v7

--- a/.github/workflows/pulumi-preview.yml
+++ b/.github/workflows/pulumi-preview.yml
@@ -50,6 +50,18 @@ jobs:
           sudo zerotier-cli peers || true
           exit 1
 
+      - name: Write kubeconfig
+        env:
+          KUBECONFIG_CONTENT: ${{ secrets.KUBECONFIG }}
+        run: |
+          # The Pulumi program's k8s provider uses the ambient kubeconfig to reach
+          # the k3s API (https://10.144.180.10:6443, over ZeroTier). Without it,
+          # Helm templating falls back to kubeVersion 1.20.0 and charts fail.
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$KUBECONFIG_CONTENT" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
+
       - name: Pulumi preview
         uses: pulumi/actions@v7
         env:

--- a/.github/workflows/pulumi-preview.yml
+++ b/.github/workflows/pulumi-preview.yml
@@ -1,0 +1,56 @@
+name: pulumi-preview
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: pulumi-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write   # for the PR comment
+
+jobs:
+  preview:                # <- this job name is the required status-check name
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'   # matches package.json volta pin
+          cache: npm
+
+      - run: npm ci
+
+      - name: Join ZeroTier
+        uses: zerotier/github-action@v1.0.1
+        with:
+          network_id: ${{ secrets.ZEROTIER_NETWORK_ID }}
+          auth_token: ${{ secrets.ZEROTIER_CENTRAL_TOKEN }}
+
+      - name: Wait for state backend over ZeroTier
+        run: |
+          for i in $(seq 1 30); do
+            if ping -c1 -W1 10.144.180.10 >/dev/null 2>&1; then
+              echo "backend reachable"; exit 0
+            fi
+            echo "waiting for ZeroTier route... ($i)"; sleep 2
+          done
+          echo "state backend 10.144.180.10 unreachable over ZeroTier"; exit 1
+
+      - name: Pulumi preview
+        uses: pulumi/actions@v7
+        env:
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS: '1'
+        with:
+          command: preview
+          stack-name: dev
+          cloud-url: ${{ secrets.PULUMI_BACKEND_URL }}
+          diff: true
+          comment-on-pr: true
+          comment-on-summary: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds two workflows so the dev stack can be driven from GitHub CI against the DIY Postgres state backend over ZeroTier:

- pulumi-preview.yml: on PRs to main, runs `pulumi preview` and posts the diff back as a PR comment. The `preview` job is the required status check for the main branch ruleset.
- pulumi-deploy.yml: on push to main, runs `pulumi up` gated behind the `production` GitHub Environment (manual approval).

Both use the official pulumi/actions@v7 + actions/setup-node (no mise in CI); the pinned @pulumi/pulumi 3.178.0 SDK is reproduced via `npm ci`. Runners join ZeroTier via zerotier/github-action@v1.0.1 (auto-deauthorized in the post step) and connect to 10.144.180.10:5432. Backend URL and passphrase come from GitHub secrets.