### PR TITLE
docs: document the GitHub Actions CI/CD deploy flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ This project manages a k3s cluster configuration using Pulumi with the Node.js r
 - **Runtime manager**: This project uses [`mise`](https://mise.jdx.dev/) to manage the Node.js runtime and tool versions. **Do NOT use `npx`** to run project tools — use the binaries directly (use `mise x <tool>`)
 - **TypeScript check**: `mise x -- pulumi preview --diff --json` will check the code for syntax errors before generating the preview.
 - **Package manager**: `npm`
+- **State backend**: Pulumi state lives in a self-hosted Postgres backend (`deploy/state-backend/`); `mise` injects `PULUMI_BACKEND_URL` + `PULUMI_CONFIG_PASSPHRASE` automatically. The k8s provider uses the ambient kubeconfig (k3s API over ZeroTier at `https://10.144.180.10:6443`).
+- **CI/CD**: `.github/workflows/` run `pulumi preview` on PRs (posted as a PR comment; required `preview` check on `main`) and a manually-approved `pulumi up` on push to `main`, via `pulumi/actions` over ZeroTier. Details and required secrets are in `README.md`.
 
 ## Core Structure
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,48 @@ k3s uses a config file `k3s-kluster.yml`, this file needs to be copied to `/etc/
 
 ## Use pulumi to deploy the configurations
 
+State lives in a self-hosted Postgres backend (see `deploy/state-backend/`), and
+[`mise`](https://mise.jdx.dev/) injects the backend URL and the config passphrase from
+the git-ignored `.pulumi.backend` / `.pulumi.secret` files (falling back to `secret-tool`).
+So a local deploy is just:
+
 ```
-$ secret-tool lookup xdg:service pulumi | read -r PULUMI_CONFIG_PASSPHRASE; export PULUMI_CONFIG_PASSPHRASE
-$ pulumi up
+$ mise run state-db:up          # first time / after a reboot: start the state backend
+$ mise x -- pulumi preview --diff
+$ mise x -- pulumi up
 ```
+
+The k8s provider uses the ambient kubeconfig (`~/.kube/config`), which points at the k3s
+API over ZeroTier (`https://10.144.180.10:6443`).
+
+## Continuous deployment (GitHub Actions)
+
+Deploys can also be driven from GitHub CI. Two workflows under `.github/workflows/` use
+[`pulumi/actions`](https://github.com/pulumi/actions) (not `mise`; the pinned
+`@pulumi/pulumi` SDK is reproduced via `npm ci`):
+
+- **`pulumi-preview.yml`** — on every PR to `main`, runs `pulumi preview` and posts the
+  diff as a PR comment. Its `preview` job is a **required status check** for `main`.
+- **`pulumi-deploy.yml`** — on push to `main`, runs `pulumi up`, gated behind the
+  `production` GitHub Environment (**manual approval required** before anything applies).
+
+Runners reach the homelab over ZeroTier: [`zerotier/github-action`](https://github.com/zerotier/github-action)
+authorizes an ephemeral member (auto-removed in its post step), the job waits for TCP
+`10.144.180.10:5432`, then Pulumi talks to the Postgres state backend and the k3s API
+(`:6443`) over that same ZeroTier path.
+
+### Required configuration
+
+| GitHub secret | Value |
+|---------------|-------|
+| `PULUMI_BACKEND_URL` | contents of `.pulumi.backend` (`postgres://…?sslmode=require`) |
+| `PULUMI_CONFIG_PASSPHRASE` | contents of `.pulumi.secret` |
+| `KUBECONFIG` | a self-contained kubeconfig whose server is `https://10.144.180.10:6443` |
+| `ZEROTIER_NETWORK_ID` | the ZeroTier network id for `10.144.0.0/16` |
+| `ZEROTIER_CENTRAL_TOKEN` | ZeroTier Central API token (my.zerotier.com → Account) |
+
+Plus: a `production` Environment with yourself as a **required reviewer**, and a `main`
+branch ruleset (block direct pushes, require a PR, require the `preview` check).
 
 ## Per Pod Cert for mTLS
 This is done by bootstraping a self-signed CA in the cluster using cert-manager,

--- a/deploy/state-backend/README.md
+++ b/deploy/state-backend/README.md
@@ -2,7 +2,9 @@
 
 A lightweight PostgreSQL container that holds this project's Pulumi state (DIY
 `postgres://` backend). It replaces the old local file backend so the stack can
-be driven from any host on the LAN / ZeroTier and, later, from GitHub CI.
+be driven from any host on the LAN / ZeroTier and from GitHub CI (the
+`.github/workflows/` jobs reach this backend over ZeroTier — see the
+"Continuous deployment" section of the top-level `README.md`).
 
 It is a **bootstrap dependency**: Pulumi needs it running to do anything, so it
 is *not* managed by Pulumi. It runs directly on the homelab host via Podman,


### PR DESCRIPTION
Now that preview-on-PR and gated up-on-main are live, update the docs:

- README.md: replace the stale file-backend `pulumi up` instructions with the
  current mise/Postgres-backend local flow, and add a "Continuous deployment"
  section covering both workflows, the manual-approval gate, the ZeroTier +
  kubeconfig reachability path, and the required secrets/environment/ruleset.
- AGENTS.md: note the state backend, kubeconfig-over-ZeroTier provider, and the
  CI/CD workflows under the Development Environment section.
- deploy/state-backend/README.md: the backend is now driven from CI, not "later".

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
