### PR TITLE
fix(authelia): allow sync-nas through the ACL

### DIFF
--- a/src/serving/authelia-static/02-acl.yaml
+++ b/src/serving/authelia-static/02-acl.yaml
@@ -55,6 +55,7 @@ access_control:
 
   - domain:
     - 'sync.{{ env "CONFIG_EXTRA_DOMAIN" }}'
+    - 'sync-nas.{{ env "CONFIG_EXTRA_DOMAIN" }}'
     subject: "group:users"
     policy: two_factor
 


### PR DESCRIPTION
## Problem

The `syncthing-nas` instance added in fee64d9 is served at
`sync-nas.unlimited-code.works` with `enableAuth: true`, but `02-acl.yaml` never
got a matching rule. With `default_policy: deny`, the GUI was unreachable — so
the instance has been running for 7 days with no way to log in and pair folders.

This surfaced while chasing a `404 page not found`, which turned out to be a
separate, now-resolved issue: the DNS record had been created as
`syncthing-nas.unlimited-code.works` while the HTTPRoute hostname is
`sync-nas.unlimited-code.works`, so requests reached the gateway with no
matching route. With the correct record now in place the host resolves and the
route matches, and the response becomes the expected `403` from Authelia:

```
$ curl -o /dev/null -w '%{http_code}\n' https://sync-nas.unlimited-code.works/
403
```

For comparison, the working sibling `sync.unlimited-code.works` returns `302` to
`auth.unlimited-code.works`.

## Change

Add the host to the existing `sync.` rule, giving it the same policy as the
original instance (`group:users`, `two_factor`).

## Expected preview

Only two resources should change — the Authelia ConfigMap (replaced, `~data`)
and its Deployment (rolled to pick up the new ConfigMap name). Note this means
a brief Authelia restart, so SSO *logins* blip; existing sessions live in Redis
and are unaffected.

If the preview also shows the 16 `pulumi:providers:kubernetes` resources
updating, that is worth a look independently of this PR — see below.

## Unrelated observations

Two things noticed while working on this, both pre-existing and **not** addressed here:

1. **`pulumi-deploy` for #147 (`41fece8`) has been `waiting` on the `production`
   approval gate for ~70h.** Because the deploy workflow uses a global
   `concurrency: pulumi-deploy` with `cancel-in-progress: false`, merging this PR
   will queue its deploy behind that run — it won't apply until the stale run is
   approved or cancelled.

2. **Local `pulumi preview` reports all 16 k8s providers as updates**, diffing only
   `kubeconfig: [secret]`. 7e27e12 moved the provider kubeconfig from *path* to
   *content* to stop exactly this flip-flop, but that only holds while the content
   matches, and the local kubeconfig differs from CI's `KUBECONFIG` secret. If so,
   the flip-flop was relocated rather than fixed, and each local `up` would fight
   the next CI run. CI's preview on this PR is the cheap test: if it shows only the
   two Authelia resources, the churn is local-vs-CI and not real drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)