### PR TITLE
fix(authelia): raise memory limit to 512Mi, drop log level to info

### DIFF
--- a/src/serving/authelia-static/00-main.yaml
+++ b/src/serving/authelia-static/00-main.yaml
@@ -13,7 +13,10 @@ certificates_directory: /tls
 theme: "light"
 
 log:
-  level: "debug"
+  # debug logs several lines per forward-auth request, which is a lot of churn
+  # under a syncthing GUI's /rest/* polling. Raise back to debug temporarily when
+  # diagnosing an authorization decision.
+  level: "info"
 
 totp:
   issuer: {{ env "CONFIG_EXTRA_DOMAIN" | msquote }}

--- a/src/serving/authelia.ts
+++ b/src/serving/authelia.ts
@@ -170,8 +170,12 @@ export class Authelia extends pulumi.ComponentResource<AutheliaArgs> {
                 name: "authelia",
                 image: versions.image.authelia,
                 resources: {
+                    // Memory limit must leave burst headroom above the ~67Mi
+                    // steady state: a syncthing GUI polls many /rest/* endpoints
+                    // and each one is a forward-auth round trip, which OOMKilled
+                    // authelia at the old 128Mi (requests == limits, no burst).
                     requests: { cpu: "20m", memory: "128Mi" },
-                    limits: { cpu: "2000m", memory: "128Mi" }
+                    limits: { cpu: "2000m", memory: "512Mi" }
                 },
                 command: ["authelia"],
                 ports: {


### PR DESCRIPTION
## Problem

Authelia was **OOMKilled** (exit 137) about four minutes after the sync-nas ACL
rollout in #148:

```
Last State:  Terminated
  Reason:    OOMKilled
  Exit Code: 137
```

The logs from the killed container show what it was doing: serving the
forward-auth burst from a syncthing GUI. Syncthing's web UI polls a lot of
`/rest/*` endpoints (`/rest/system/status`, `/rest/stats/folder`,
`/rest/system/connections`, `/rest/events/disk`, …) and every one is a
forward-auth round trip plus an "updated profile" backend check.

The limits left no room for that:

- steady state is **~67Mi** (`kubectl top`) against a **128Mi** limit
- `requests == limits == 128Mi`, so there was **zero** burst headroom
- `log.level: debug` emits several lines per forward-auth request
- there are now **two** syncthing instances behind auth, doubling the polling load

16b41ee raised the cpu limit to 2000m for this same class of load ("was
throttling SSO logins"). That cleared the CPU throttle, and the next bottleneck
turned out to be memory.

## Change

- memory limit `128Mi` → `512Mi`, keeping requests at `128Mi` for burst headroom.
  QoS is unaffected — the pod is **already** `Burstable`, since cpu requests 20m
  != limits 2000m, so splitting the memory request/limit introduces no
  eviction-priority regression.
- `log.level` `debug` → `info`.

## Expected preview

Same shape as #148: the Authelia ConfigMap replaced (`~data`, for the log level)
and its Deployment updated (new ConfigMap name + the resources change). One
rollout covers both edits. Brief SSO *login* blip; existing sessions live in
Redis and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)