### PR TITLE
ci: freeze bitnami OCI charts, gate npm automerge on a no-op preview

### DIFF
--- a/.github/workflows/pulumi-preview.yml
+++ b/.github/workflows/pulumi-preview.yml
@@ -62,6 +62,38 @@ jobs:
           chmod 600 "$HOME/.kube/config"
           echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
 
+      - name: Classify the PR
+        id: classify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Escape hatch: label a PR `expect-changes` when a dependency bump is
+          # *supposed* to move resources, e.g. a deliberate @pulumi/kubernetes
+          # upgrade that renders fields differently.
+          OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'expect-changes') }}
+        run: |
+          # Only the Pulumi program and its stack config can legitimately change
+          # what we deploy. A PR touching neither -- lock file maintenance, npm
+          # bumps, workflow or docs edits -- must preview as a no-op, and if it
+          # doesn't, something moved behind our back. This is the gate that
+          # would have caught @pulumi/pulumi 3.253.0 silently dropping 238
+          # resources (commit c93d8d78) instead of automerging it.
+          if [ "$OVERRIDE" = 'true' ]; then
+            echo 'expect-no-changes=false' >> "$GITHUB_OUTPUT"
+            echo 'PR is labelled expect-changes; skipping the no-op gate'
+            exit 0
+          fi
+          changed=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')
+          echo "changed files:"; echo "$changed"
+          if grep -qE '^(src/|Pulumi\.)' <<<"$changed"; then
+            echo 'expect-no-changes=false' >> "$GITHUB_OUTPUT"
+            echo 'PR touches the Pulumi program or its config; a diff is expected'
+          else
+            echo 'expect-no-changes=true' >> "$GITHUB_OUTPUT"
+            echo 'PR cannot legitimately change infrastructure; requiring a no-op preview'
+          fi
+
       - name: Pulumi preview
         uses: pulumi/actions@v7
         env:
@@ -75,3 +107,18 @@ jobs:
           comment-on-pr: true
           comment-on-summary: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Deliberately a second preview rather than `expect-no-changes` on the
+      # step above: pulumi/actions awaits the preview before it posts the PR
+      # comment and the summary (src/main.ts:121 vs :160), so a non-zero exit
+      # there throws and we lose the diff in exactly the case we need to read
+      # it. The step above always reports; this one only decides pass/fail. The
+      # CLI and the login credentials are already on the runner from it.
+      - name: Require a no-op preview
+        if: steps.classify.outputs.expect-no-changes == 'true'
+        env:
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS: '1'
+          PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
+        run: |
+          pulumi preview --stack dev --non-interactive --diff --expect-no-changes

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,25 @@
       dependencyDashboardApproval: true,
     },
     {
+      // bitnami moved their charts to an OCI-only registry. 20.3.0 is the last
+      // redis version published as an https .tgz under charts.bitnami.com;
+      // every version from 20.13.4 up resolves to
+      // oci://registry-1.docker.io/bitnamicharts/redis. We render charts with
+      // helm.v3.Chart, which cannot pull OCI refs and dies with
+      // `invalid_reference: invalid tag`, taking down the whole preview rather
+      // than just that chart (see PR #139). Keep these frozen until #100 moves
+      // us to helm.v3.Release. Matched on the registry instead of on `redis` so
+      // any future chart from this host is covered too; note sealed-secrets
+      // lives on bitnami.github.io and is *not* affected.
+      matchDatasources: [
+        'helm',
+      ],
+      matchRegistryUrls: [
+        'https://charts.bitnami.com/bitnami',
+      ],
+      enabled: false,
+    },
+    {
       matchUpdateTypes: [
         'minor',
         'patch',
@@ -67,6 +86,12 @@
         'pin',
         'digest',
       ],
+      // A version bump here always produces a real Kubernetes diff, so the
+      // zero-diff automerge gate in pulumi-preview.yml can't be the reviewer.
+      // The `deps-non-major` rule above matches these too (it has no
+      // matchDepTypes) and would otherwise leak its `automerge: true` in here,
+      // so turn it back off explicitly: application updates get eyeballed.
+      automerge: false,
       groupName: 'applications with non-major changes',
       groupSlug: 'apps-non-major',
     },


### PR DESCRIPTION
Three related renovate/CI governance changes. Blocks the redis bump that has been failing preview, stops application updates from automerging unreviewed, and adds a gate that requires a no-op preview where a diff would be a bug.

## 1. Freeze charts from charts.bitnami.com

PR #139 has failed preview continuously since it opened, with:

```
failed to generate YAML for specified Helm chart: failed to pull chart:
invalid_reference: invalid tag
```

bitnami republished their charts to an OCI-only registry. From their index:

| version | url |
|---|---|
| 20.3.0 (current pin) | `https://charts.bitnami.com/bitnami/redis-20.3.0.tgz` |
| 20.13.4 (the bump) | `oci://registry-1.docker.io/bitnamicharts/redis:20.13.4` |

20.13.4 is the first redis version published OCI-only, and every version above it (through 27.0.18) is too. `helm.v3.Chart` cannot pull OCI refs, and it takes down the entire preview rather than just that chart.

**Only redis is affected.** `sealed-secrets` is on `bitnami.github.io`, which is the sealed-secrets project's own GitHub Pages, and 2.19.1 is a plain release tarball. The proof is in the failing run itself: it *rendered* sealed-secrets 2.19.1 and printed its diff (`helm.sh/chart: "sealed-secrets-2.18.0" => "sealed-secrets-2.19.1"` across ~10 resources) before dying on redis.

Matched on `matchRegistryUrls` rather than on the name `redis`, so the rule describes the actual invariant — charts from this host cannot be pulled — and covers any future chart added from it. Unfreeze via #100.

## 2. Stop automerging application updates

The `deps-non-major` rule sets `automerge: true` with no `matchDepTypes` restriction, so it also matched helm/container deps. `apps-non-major` only overrode `groupName`/`groupSlug`, so application updates inherited automerge and were landing without anyone looking at them. A chart or image version bump always produces a real Kubernetes diff, so no automated diff check can substitute for reading it — hence `automerge: false` rather than folding it into the gate below.

## 3. Require a no-op preview where a diff would be a bug

A PR that touches neither `src/` nor `Pulumi.*` cannot legitimately change what we deploy. Lock file maintenance, npm bumps, and workflow or docs edits now have to preview clean to merge. This is the check that would have caught `@pulumi/pulumi` 3.253.0 silently dropping 238 resources (c93d8d78) instead of automerging it. The baseline is healthy — #147 previewed `608 unchanged`.

Two implementation notes:

- It runs as a **second** preview inside the existing `preview` job rather than as `expect-no-changes` on the first. `pulumi/actions` awaits the preview at `src/main.ts:121` and posts the PR comment and summary at `:160`, so a non-zero exit there throws and the diff is discarded — in precisely the case worth reading. Confirmed empirically: #139's failing previews have posted zero comments. The first step always reports; the second only decides pass/fail. The CLI and login credentials are already on the runner from the first step.
- Keeping it in the same job keeps `preview` a single always-reporting required check, so no PR can hang pending on a skipped job.

Label a PR `expect-changes` to opt out, for cases like a deliberate `@pulumi/kubernetes` upgrade that is *supposed* to move resources.

## Verification

`renovate.json5` validated against renovate 44.2.2, with a negative control: the validator rejects a bogus `matchBogusNonsenseUrls` at `packageRules[1]` while accepting `matchRegistryUrls`, so the pass isn't vacuous.

## Follow-up

Once this lands, redis drops out of the `apps-non-major` group and renovate should rebase #139 to carry only the immich / kubectl / spoolman / sealed-secrets bumps. If the freeze didn't take, the failure mode is loud: redis gets bumped again and preview fails identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)