### PR TITLE
ci: deploy on merge instead of behind a blind approval gate

### DIFF
--- a/.github/workflows/pulumi-deploy.yml
+++ b/.github/workflows/pulumi-deploy.yml
@@ -7,6 +7,12 @@ on:
 concurrency:
   group: pulumi-deploy       # global: never overlap applies
   cancel-in-progress: false  # let an in-flight apply finish
+  # `queue: single` is the default, so at most one run waits behind the applying
+  # one and a newer push cancels the older waiter. Bursts therefore collapse to
+  # "finish the current apply, then apply the newest main" instead of replaying
+  # intermediate commits. This only holds because nothing blocks on a human any
+  # more: a run parked on an approval gate counts as in-progress, which is how
+  # #147 sat here for 70 hours and stalled every deploy behind it.
 
 permissions:
   contents: read
@@ -14,7 +20,12 @@ permissions:
 jobs:
   up:
     runs-on: ubuntu-latest
-    environment: production   # <- requires manual approval (see setup)
+    # No `environment: production` gate. The approval used to run *before* any
+    # step, so there was no plan on screen to approve -- it only controlled when
+    # an apply happened, at the cost of letting main silently drift from the
+    # cluster. Review now lives on the PR: `preview` is a required check and the
+    # branch ruleset requires branches to be up to date with main, so the diff
+    # you read is computed from the same inputs this applies. Merging deploys.
     steps:
       - uses: actions/checkout@v4
 
@@ -72,3 +83,32 @@ jobs:
           cloud-url: ${{ secrets.PULUMI_BACKEND_URL }}
           diff: true
           comment-on-summary: true
+
+      - name: Alert on a failed apply
+        if: failure()
+        env:
+          WEBHOOK_URL: ${{ secrets.HAOS_DEPLOY_WEBHOOK_URL }}
+          # Via env, not `${{ }}` inline, so a commit message can't break out
+          # into the shell.
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Nothing stands between a merge and a live apply now, so a broken
+          # apply is otherwise entirely silent -- you'd believe main was
+          # deployed when it isn't. Posts to a Home Assistant webhook, which
+          # drives the `kluster-code deploy failed` automation -> mobile push.
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo '::warning::HAOS_DEPLOY_WEBHOOK_URL is unset; no alert sent'
+            exit 0
+          fi
+          jq -n \
+            --arg sha "${GITHUB_SHA:0:8}" \
+            --arg msg "$(printf '%s' "$COMMIT_MSG" | head -1)" \
+            --arg url "$RUN_URL" \
+            '{
+               title: "kluster-code deploy failed",
+               message: "pulumi up failed on \($sha): \($msg)",
+               url: $url,
+             }' \
+            | curl -sS --fail -m 15 -X POST "$WEBHOOK_URL" \
+                -H 'Content-Type: application/json' --data @-


### PR DESCRIPTION
Removes the `production` environment gate from `pulumi-deploy.yml`, moving review to the PR where a diff actually exists, and adds a failure alert to cover what the gate was implicitly providing.

## The gate was never reviewing anything

`environment: production` gates a job *before its first step runs*. There was no checkout, no preview, no plan — clicking Approve reviewed nothing. `diff: true` prints a diff, but that's `pulumi up` narrating itself while it applies. The gate's only real effect was controlling *when* an apply happened.

That turned out to be expensive:

- **#147 sat on the gate for 70 hours.** A run parked on an approval still counts as in-progress for the `pulumi-deploy` concurrency group, so it stalled every deploy queued behind it.
- **A late approval applies its own stale SHA.** Approving #147 after 70 hours applied a 70-hour-old tree, briefly reverting the authelia `sync-nas` ACL fix that had merged in the meantime, until the queued run re-applied it.

## Review moves to the PR

`preview` is a required check, and the branch ruleset now has `strict_required_status_checks_policy: true`, so a PR cannot merge while behind main. That was the precondition for treating the PR preview as approval evidence: the plan you read is computed from the same inputs that get applied. Merging is deploying.

The residual is that `pulumi preview` diffs against live cluster state at preview time while `pulumi up` re-diffs at apply time — strict makes the git inputs identical, not the cluster state. That gap is accepted here in exchange for removing the silent-drift failure mode.

## Concurrency now means what it says

With no human in the group, the existing settings finally behave correctly. `queue: single` is the GitHub default, so at most one run waits behind an in-flight apply and a newer push cancels the older waiter. A burst collapses to "finish the current apply, then apply the newest main" rather than replaying intermediate commits. No change needed here beyond documenting why — the head-of-line blocking was caused by the gate, not by these settings.

## Failure alerting

Removing the gate means a failed apply is otherwise completely silent — main would look deployed when it isn't. Failures now POST to a Home Assistant webhook, driving a `kluster-code deploy failed` automation to a mobile push.

- The webhook URL is in the `HAOS_DEPLOY_WEBHOOK_URL` repo secret.
- The commit message is passed through the environment rather than interpolated inline via `${{ }}`, so it cannot break out into the shell. Payload construction was tested against a message containing `"quotes" & $(whoami)` and backticks plus a second line: quotes escape, nothing expands, multi-line truncates to the first line.
- The webhook was verified end-to-end from the public internet before this PR: `HTTP 200`, automation `last_triggered` confirmed, no errors in the HA log.

## Note

The `production` environment still exists in repo settings but nothing references it after this merge. Worth deleting so it doesn't look load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)