### PR TITLE
fix(serving): disable traefik 60s readTimeout that broke large uploads

### DIFF
--- a/src/serving/traefik.ts
+++ b/src/serving/traefik.ts
@@ -115,7 +115,30 @@ export class Traefik extends pulumi.ComponentResource<TraefikArgs> {
                             tls: {
                                 enabled: true
                             }
-                        }
+                        },
+                        transport: {
+                            respondingTimeouts: {
+                                // readTimeout covers reading the *entire* request,
+                                // including the body, and defaults to 60s (since
+                                // traefik v2.11.2). Any upload slower than that is
+                                // cut off mid-body and surfaces to the client as a
+                                // 502 -- e.g. Immich video uploads, which reliably
+                                // died at exactly 60s.
+                                //
+                                // This has to live on the entrypoint: readTimeout is
+                                // a property of the listening socket's http.Server,
+                                // applied before routing, so it cannot be scoped to a
+                                // single route. Gateway API's HTTPRoute `timeouts`
+                                // only caps the gateway->backend request and cannot
+                                // extend the client body deadline.
+                                //
+                                // 0 disables it, restoring the pre-2.11.2 behaviour.
+                                // Tradeoff: no upstream-imposed bound on how long a
+                                // client may take to send a body, on any service
+                                // behind websecure.
+                                readTimeout: 0,
+                            },
+                        },
                     }
                 },
                 // Default TLSOption CR. Kept even after the Gateway API


### PR DESCRIPTION
## Problem

Immich video uploads through the web UI fail. The visible symptom is a 502 in the browser and `Failed to upload asset` in `immich-server`, which points at Immich or storage — but neither is at fault.

Traefik's entrypoint `respondingTimeouts.readTimeout` defaults to **60s** and, per [upstream docs](https://doc.traefik.io/traefik/reference/install-configuration/entrypoints/), covers *"the maximum duration for reading the entire request, **including the body**"*. Any upload slower than a minute gets cut off mid-body; Traefik then fails the forwarded request and returns 502.

## Evidence

From the traefik access log, 28 of 29 `POST /api/assets` in a two-hour window:

```
04:49:26  "POST /api/assets" 502 60256ms
04:51:07  "POST /api/assets" 502 60421ms
03:57:14  "POST /api/assets" 201 30629ms   <- the one success, 30.6s
```

Everything that crossed 60s died at 60000ms on the nose. `immich-server` recorded these as `Upload was cancelled` / `Client aborted request` — that's the *consequence* of Traefik dropping the connection, not the cause, which is what makes this misleading to debug from the app logs.

## Not a regression from the chart bump

`git log -S respondingTimeouts` / `-S readTimeout` come back empty — this repo has never configured it. 60s has been the upstream default since **traefik v2.11.2**, so this predates the recent 33.2.1 → 41.0.2 bump. It only started biting once uploads got large enough to cross the threshold.

## Why entrypoint-level and not per-route

`readTimeout` is enforced by the listening socket's `http.Server` before routing happens, so it can't be scoped to one route. Gateway API's `HTTPRoute.spec.rules[].timeouts` only exposes `request`/`backendRequest`, which bound the gateway→backend call and cannot extend the client body deadline. So this necessarily applies to all of `websecure`.

## Tradeoff

`0` restores pre-2.11.2 behaviour. The cost is that no service behind `websecure` has an upstream-imposed bound on how long a client may take to send a request body (the slowloris case the default was added to guard against). Happy to swap for a large bounded value like `30m` instead if that's preferred.

## Verification

Helm isn't installed here, so I checked the rendered output by hand against chart 41.0.2:

- `_podtemplate.tpl:735` guards with `{{- if and (ne .readTimeout nil) (toString .readTimeout) }}` — the `toString` is deliberate, so the value survives Go templates treating `0` as falsy and the flag is emitted rather than silently dropped.
- `values.schema.json` types `readTimeout` as `["string","integer","null"]`, so the integer `0` passes the now-enforced schema.

Result: `--entryPoints.websecure.transport.respondingTimeouts.readTimeout=0`.

Not deployed — leaving that to the normal preview → approve flow.

## Unrelated issues found while investigating

Filing here as notes, not addressed in this PR:

1. `immich-server` has been **OOMKilled 8 times** (exit 137, most recent 2026-07-28) against its 3Gi limit. The comment at `src/immich/index.ts:124` already anticipates ffmpeg tonemap transcoding blowing past 2Gi; 3Gi doesn't look like enough either.
2. Storage-layer I/O errors during transcode — `Error writing trailer: Input/output error`, `Bad file descriptor` — plus 3× `IntegrityService: File failed checksum`. Points at JuiceFS and deserves its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)