### PR TITLE
immich: change database drill to every 3 month

### DIFF
--- a/src/immich/index.ts
+++ b/src/immich/index.ts
@@ -414,7 +414,7 @@ export class Immich extends pulumi.ComponentResource<ImmichArgs> {
         });
         new k8s.batch.v1.CronJob(`${name}-restore-drill`, {
             spec: {
-                schedule: "0 4 1 * *",
+                schedule: "0 4 1 */3 *",
                 concurrencyPolicy: 'Forbid',
                 failedJobsHistoryLimit: 1,
                 successfulJobsHistoryLimit: 1,


### PR DESCRIPTION
This reduces storage cost. Restoring means transferring lots of data out of
S3 with a charge.
