### PR TITLE
ci: move the no-op gate into a workflow that merges the PR itself

### DIFF
--- a/.github/workflows/noop-automerge.yml
+++ b/.github/workflows/noop-automerge.yml
@@ -1,0 +1,173 @@
+name: noop-automerge
+
+# A PR that touches neither the Pulumi program (`src/`) nor its stack config
+# (`Pulumi.*`) -- lock file maintenance, npm bumps, workflow or docs edits --
+# cannot legitimately change what we deploy. This workflow proves that with a
+# `--expect-no-changes` preview and then merges the PR unattended.
+#
+# It is deliberately its own workflow rather than a step in pulumi-preview.yml,
+# which runs for *every* PR and only ever reports a diff. The decision "this may
+# merge without a human" gets its own trigger condition, its own log and its own
+# red X. The zero-diff proof is the gate that would have caught @pulumi/pulumi
+# 3.253.0 silently dropping 238 resources (commit c93d8d78) instead of
+# automerging it.
+#
+# Note the merge here does NOT run pulumi-deploy: pushes made with GITHUB_TOKEN
+# do not start new workflow runs. That is fine by construction -- we merged
+# precisely because the preview was empty, so the apply we skipped would have
+# been a no-op. main gets applied again on the next PR that carries a real diff.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+concurrency:
+  group: noop-automerge-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write        # rebase-merge the PR
+  pull-requests: write   # approve, arm/disarm auto-merge
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_REPO: ${{ github.repository }}
+  PR: ${{ github.event.pull_request.number }}
+
+jobs:
+  classify:                 # cheap: no checkout, no ZeroTier, no npm
+    runs-on: ubuntu-latest
+    outputs:
+      noop: ${{ steps.classify.outputs.noop }}
+    steps:
+      - name: Classify the PR
+        id: classify
+        env:
+          # Escape hatch: label a PR `expect-changes` when a bump is *supposed*
+          # to move resources, e.g. a deliberate @pulumi/kubernetes upgrade that
+          # renders fields differently. Such a PR wants human eyes on the diff.
+          OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'expect-changes') }}
+          DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          if [ "$OVERRIDE" = 'true' ]; then
+            echo 'noop=false' >> "$GITHUB_OUTPUT"
+            echo 'PR is labelled expect-changes; leaving it to a human'
+            exit 0
+          fi
+          if [ "$DRAFT" = 'true' ]; then
+            # Marking a PR draft is how you park one you are still editing;
+            # `ready_for_review` brings it back through here.
+            echo 'noop=false' >> "$GITHUB_OUTPUT"
+            echo 'PR is a draft; not merging it'
+            exit 0
+          fi
+          changed=$(gh api --paginate "repos/$GH_REPO/pulls/$PR/files" --jq '.[].filename')
+          echo "changed files:"; echo "$changed"
+          if grep -qE '^(src/|Pulumi\.)' <<<"$changed"; then
+            echo 'noop=false' >> "$GITHUB_OUTPUT"
+            echo 'PR touches the Pulumi program or its config; a diff is expected'
+          else
+            echo 'noop=true' >> "$GITHUB_OUTPUT"
+            echo 'PR cannot legitimately change infrastructure; requiring a no-op preview'
+          fi
+
+      - name: Disarm auto-merge if the PR stopped qualifying
+        if: steps.classify.outputs.noop != 'true'
+        run: |
+          # Arming is sticky. Once auto-merge is on GitHub merges the moment
+          # `preview` goes green, even if a later push started touching src/ or
+          # someone added `expect-changes` in the meantime. Take it back.
+          if [ "$(gh pr view "$PR" --json autoMergeRequest --jq '.autoMergeRequest != null')" = 'true' ]; then
+            gh pr merge --disable-auto "$PR"
+            echo "::warning::auto-merge disarmed; this PR now needs a human"
+          fi
+
+  merge:
+    needs: classify
+    if: needs.classify.outputs.noop == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'   # matches package.json volta pin
+          cache: npm
+
+      - run: npm ci
+
+      - name: Join ZeroTier
+        uses: zerotier/github-action@v1.0.1
+        with:
+          network_id: ${{ secrets.ZEROTIER_NETWORK_ID }}
+          auth_token: ${{ secrets.ZEROTIER_CENTRAL_TOKEN }}
+
+      - name: Wait for state backend over ZeroTier
+        run: |
+          echo "ZeroTier networks:"; sudo zerotier-cli listnetworks || true
+          # Gate on the real dependency (TCP 5432), not ICMP. A fresh runner may
+          # need a while to establish a ZeroTier path to the NAT'd homelab peer.
+          for i in $(seq 1 60); do
+            if timeout 3 bash -c 'cat < /dev/null > /dev/tcp/10.144.180.10/5432' 2>/dev/null; then
+              echo "state backend 10.144.180.10:5432 reachable after ${i} tries"; exit 0
+            fi
+            if [ $((i % 10)) -eq 0 ]; then
+              echo "still waiting ($i); ZeroTier peers:"; sudo zerotier-cli peers || true
+            fi
+            sleep 3
+          done
+          echo "::error::state backend 10.144.180.10:5432 unreachable over ZeroTier after 180s"
+          sudo zerotier-cli listnetworks || true
+          sudo zerotier-cli peers || true
+          exit 1
+
+      - name: Write kubeconfig
+        env:
+          KUBECONFIG_CONTENT: ${{ secrets.KUBECONFIG }}
+        run: |
+          # The Pulumi program's k8s provider uses the ambient kubeconfig to reach
+          # the k3s API (https://10.144.180.10:6443, over ZeroTier). Without it,
+          # Helm templating falls back to kubeVersion 1.20.0 and charts fail.
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$KUBECONFIG_CONTENT" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
+
+      - name: Require a no-op preview
+        uses: pulumi/actions@v7
+        env:
+          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
+          PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS: '1'
+        with:
+          command: preview
+          stack-name: dev
+          cloud-url: ${{ secrets.PULUMI_BACKEND_URL }}
+          diff: true
+          expect-no-changes: true
+          # No PR comment: pulumi-preview.yml already posts the readable diff for
+          # this same commit, and the action awaits the preview before it
+          # comments (src/main.ts:121 vs :160), so a failed expectation would
+          # throw before the comment lands anyway. The summary is enough here --
+          # this run only decides pass/fail.
+          comment-on-pr: false
+          comment-on-summary: true
+
+      - name: Approve
+        run: |
+          # Cosmetic today (the `main` ruleset requires 0 approvals) but it makes
+          # the PR read as "checked by something" rather than merged out of
+          # nowhere, and it keeps working if a review requirement is ever added.
+          gh pr review --approve "$PR" \
+            --body 'Preview is a no-op and the PR touches neither `src/` nor `Pulumi.*`.'
+
+      - name: Merge when the required checks pass
+        run: |
+          # Arm GitHub's auto-merge instead of merging outright: `preview` in
+          # pulumi-preview.yml is the required check and is still running at this
+          # point, and the ruleset also requires the branch to be up to date with
+          # main. GitHub applies both conditions and merges when they hold --
+          # cheaper and less racy than burning runner minutes polling for them.
+          # Rebase, not squash: it preserves the author and sets the committer to
+          # the account's primary address, unlike GitHub's squash commits.
+          gh pr merge --auto --rebase "$PR"

--- a/.github/workflows/pulumi-preview.yml
+++ b/.github/workflows/pulumi-preview.yml
@@ -1,5 +1,10 @@
 name: pulumi-preview
 
+# Runs for every PR and only ever *reports*: it renders the diff so a human can
+# read it before merging. Its `preview` job is the required status check on
+# `main`. Deciding that a PR is harmless enough to merge unattended is a
+# separate concern and lives in noop-automerge.yml.
+
 on:
   pull_request:
     branches: [main]
@@ -62,38 +67,6 @@ jobs:
           chmod 600 "$HOME/.kube/config"
           echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
 
-      - name: Classify the PR
-        id: classify
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Escape hatch: label a PR `expect-changes` when a dependency bump is
-          # *supposed* to move resources, e.g. a deliberate @pulumi/kubernetes
-          # upgrade that renders fields differently.
-          OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'expect-changes') }}
-        run: |
-          # Only the Pulumi program and its stack config can legitimately change
-          # what we deploy. A PR touching neither -- lock file maintenance, npm
-          # bumps, workflow or docs edits -- must preview as a no-op, and if it
-          # doesn't, something moved behind our back. This is the gate that
-          # would have caught @pulumi/pulumi 3.253.0 silently dropping 238
-          # resources (commit c93d8d78) instead of automerging it.
-          if [ "$OVERRIDE" = 'true' ]; then
-            echo 'expect-no-changes=false' >> "$GITHUB_OUTPUT"
-            echo 'PR is labelled expect-changes; skipping the no-op gate'
-            exit 0
-          fi
-          changed=$(gh api --paginate \
-            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename')
-          echo "changed files:"; echo "$changed"
-          if grep -qE '^(src/|Pulumi\.)' <<<"$changed"; then
-            echo 'expect-no-changes=false' >> "$GITHUB_OUTPUT"
-            echo 'PR touches the Pulumi program or its config; a diff is expected'
-          else
-            echo 'expect-no-changes=true' >> "$GITHUB_OUTPUT"
-            echo 'PR cannot legitimately change infrastructure; requiring a no-op preview'
-          fi
-
       - name: Pulumi preview
         uses: pulumi/actions@v7
         env:
@@ -107,18 +80,3 @@ jobs:
           comment-on-pr: true
           comment-on-summary: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Deliberately a second preview rather than `expect-no-changes` on the
-      # step above: pulumi/actions awaits the preview before it posts the PR
-      # comment and the summary (src/main.ts:121 vs :160), so a non-zero exit
-      # there throws and we lose the diff in exactly the case we need to read
-      # it. The step above always reports; this one only decides pass/fail. The
-      # CLI and the login credentials are already on the runner from it.
-      - name: Require a no-op preview
-        if: steps.classify.outputs.expect-no-changes == 'true'
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
-          PULUMI_K8S_SUPPRESS_HELM_HOOK_WARNINGS: '1'
-          PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
-        run: |
-          pulumi preview --stack dev --non-interactive --diff --expect-no-changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This project manages a k3s cluster configuration using Pulumi with the Node.js r
 - **TypeScript check**: `mise x -- pulumi preview --diff --json` will check the code for syntax errors before generating the preview.
 - **Package manager**: `npm`
 - **State backend**: Pulumi state lives in a self-hosted Postgres backend (`deploy/state-backend/`); `mise` injects `PULUMI_BACKEND_URL` + `PULUMI_CONFIG_PASSPHRASE` automatically. The k8s provider uses the ambient kubeconfig (k3s API over ZeroTier at `https://10.144.180.10:6443`).
-- **CI/CD**: `.github/workflows/` run `pulumi preview` on PRs (posted as a PR comment; required `preview` check on `main`) and a manually-approved `pulumi up` on push to `main`, via `pulumi/actions` over ZeroTier. Details and required secrets are in `README.md`.
+- **CI/CD**: `.github/workflows/` run `pulumi preview` on PRs (posted as a PR comment; required `preview` check on `main`) and `pulumi up` on push to `main` — merging deploys, there is no approval gate — via `pulumi/actions` over ZeroTier. A third workflow approves and auto-merges (rebase) PRs that touch neither `src/` nor `Pulumi.*`, after proving the preview is a no-op. Details and required secrets are in `README.md`.
 
 ## Core Structure
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,21 @@ Deploys can also be driven from GitHub CI. Two workflows under `.github/workflow
 
 - **`pulumi-preview.yml`** — on every PR to `main`, runs `pulumi preview` and posts the
   diff as a PR comment. Its `preview` job is a **required status check** for `main`.
-- **`pulumi-deploy.yml`** — on push to `main`, runs `pulumi up`, gated behind the
-  `production` GitHub Environment (**manual approval required** before anything applies).
+- **`pulumi-deploy.yml`** — on push to `main`, runs `pulumi up`. There is no approval
+  step: **merging is what deploys**, and review happens on the PR. A failed apply posts
+  to a Home Assistant webhook (`HAOS_DEPLOY_WEBHOOK_URL`) → phone notification, since
+  nothing else would tell you `main` isn't actually deployed.
+- **`noop-automerge.yml`** — for a PR that touches neither `src/` nor `Pulumi.*` (lock
+  file maintenance, npm bumps, workflow or docs edits), runs a second
+  `preview --expect-no-changes` and, if it really is a no-op, approves the PR and arms
+  GitHub auto-merge (rebase). That zero-diff proof is the gate that would have caught
+  `@pulumi/pulumi` 3.253.0 silently dropping 238 resources instead of automerging it.
+  Label a PR `expect-changes` to opt out (and to disarm an already-armed one).
+  Renovate deliberately no longer automerges anything itself.
+
+Note that an auto-merge does not trigger `pulumi-deploy` — pushes made with
+`GITHUB_TOKEN` don't start workflow runs. That is consistent: those merges were proven
+to be no-ops, and the next PR with a real diff applies `main` again.
 
 Runners reach the homelab over ZeroTier: [`zerotier/github-action`](https://github.com/zerotier/github-action)
 authorizes an ephemeral member (auto-removed in its post step), the job waits for TCP
@@ -46,8 +59,9 @@ authorizes an ephemeral member (auto-removed in its post step), the job waits fo
 | `ZEROTIER_NETWORK_ID` | the ZeroTier network id for `10.144.0.0/16` |
 | `ZEROTIER_CENTRAL_TOKEN` | ZeroTier Central API token (my.zerotier.com → Account) |
 
-Plus: a `production` Environment with yourself as a **required reviewer**, and a `main`
-branch ruleset (block direct pushes, require a PR, require the `preview` check).
+Plus a `main` branch ruleset (block direct pushes, require a PR, require the `preview`
+check, require branches to be up to date), and **Allow auto-merge** enabled in the
+repository settings — without it `noop-automerge.yml` cannot arm a merge.
 
 ## Per Pod Cert for mTLS
 This is done by bootstraping a self-signed CA in the cluster using cert-manager,

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,10 +10,14 @@
   patch: {
     enabled: false,
   },
-  automergeStrategy: 'squash',
+  // Merging is not renovate's job any more: .github/workflows/noop-automerge.yml
+  // merges any PR that leaves `src/` and `Pulumi.*` untouched once it has proven
+  // the preview is empty -- which covers every update renovate used to automerge
+  // here, and covers them with the zero-diff proof renovate cannot do. Two
+  // mechanisms racing would also mean whichever wins picks the merge strategy,
+  // and renovate's squash rewrites the committer to noreply@github.com.
   lockFileMaintenance: {
     enabled: true,
-    automerge: true,
   },
   ignorePaths: [
     'src/crds/**',
@@ -57,15 +61,8 @@
         'pin',
         'digest',
       ],
-      automerge: true,
       groupName: 'dependencies with non-major changes',
       groupSlug: 'deps-non-major',
-    },
-    {
-      matchDepTypes: [
-        'devDependencies',
-      ],
-      automerge: true,
     },
     {
       matchDepTypes: [
@@ -86,12 +83,9 @@
         'pin',
         'digest',
       ],
-      // A version bump here always produces a real Kubernetes diff, so the
-      // zero-diff automerge gate in pulumi-preview.yml can't be the reviewer.
-      // The `deps-non-major` rule above matches these too (it has no
-      // matchDepTypes) and would otherwise leak its `automerge: true` in here,
-      // so turn it back off explicitly: application updates get eyeballed.
-      automerge: false,
+      // These live in `Pulumi.dev.yaml` and always produce a real Kubernetes
+      // diff, so noop-automerge.yml classifies them as needing a human and
+      // never touches them. Application updates get eyeballed.
       groupName: 'applications with non-major changes',
       groupSlug: 'apps-non-major',
     },


### PR DESCRIPTION
The zero-diff gate lived as a conditional step inside `pulumi-preview.yml` and only ever produced a pass/fail on the required check — nothing acted on the verdict. #154/#155/#157 are the symptom: green, no-op, and still open, because merging was left to renovate, whose automerge could not fire (`allow_auto_merge` was off on the repo, so platform automerge was unavailable to it).

**`noop-automerge.yml`** now owns that decision, separate from the preview everyone gets:

- `classify` job (no checkout / ZeroTier / npm): PR touches neither `src/` nor `Pulumi.*`, no `expect-changes` label, not a draft. A PR with a real diff stops here for free.
- `merge` job: `pulumi preview --expect-no-changes`, then `gh pr review --approve` and `gh pr merge --auto --rebase`. Arming auto-merge rather than merging outright lets GitHub apply the remaining requirements — the required `preview` check and the up-to-date-with-main policy — instead of a runner polling for them.
- Arming is sticky, so `classify` disarms it again if a later push or an added label makes the PR stop qualifying.

`pulumi-preview.yml` goes back to one job: render the diff for a human, every PR.

Renovate stops automerging (`lockFileMaintenance`, `deps-non-major`, `devDependencies`). Everything it used to merge falls in the no-op class anyway, now with a zero-diff proof it cannot produce itself; two mechanisms racing would also mean the winner picks the merge strategy, and renovate's `squash` rewrites the committer to `noreply@github.com`.

Out-of-band: **Allow auto-merge** is now enabled in the repo settings (required by `gh pr merge --auto`); documented in `README.md`.

Note an auto-merge does not trigger `pulumi-deploy` — pushes made with `GITHUB_TOKEN` start no workflow runs. That follows from what was proven: the apply we skip is a no-op.

Opened as a draft on purpose: this PR is itself in the no-op class, so marking it **Ready for review** makes it approve and merge *itself* — which is the smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)