### PR TITLE
ci: correct what a rebase merge actually preserves

### DIFF
--- a/.github/workflows/noop-automerge.yml
+++ b/.github/workflows/noop-automerge.yml
@@ -168,6 +168,8 @@ jobs:
           # point, and the ruleset also requires the branch to be up to date with
           # main. GitHub applies both conditions and merges when they hold --
           # cheaper and less racy than burning runner minutes polling for them.
-          # Rebase, not squash: it preserves the author and sets the committer to
-          # the account's primary address, unlike GitHub's squash commits.
+          # Rebase, not squash: the original author survives onto main. A squash
+          # would rewrite it to renovate[bot] with a `(#NNN)` subject. The
+          # committer is github-actions[bot] either way -- that is whoever's
+          # token performed the merge, and it cannot be this one's own address.
           gh pr merge --auto --rebase "$PR"


### PR DESCRIPTION
Follow-up to #159, which merged itself and thereby disproved one of its own comments: the committer on `c2a8d73` is `github-actions[bot]`, not my primary address. GitHub records whichever token performed the merge. What rebase actually buys over squash is the **author** (`Aetf <aetf@unlimited-code.works>` survived), where a squash rewrites it to `renovate[bot]` with a `(#NNN)` subject — compare `90c33ee`, merged by renovate minutes earlier.

Comment-only. Also the second live exercise of `noop-automerge.yml`, this time through the ordinary open → merge path rather than `ready_for_review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)