### PR TITLE
Drop the PKCE requirement from the SplitPro OIDC client

### DIFF
--- a/src/serving/authelia-static/01-oidc.yaml
+++ b/src/serving/authelia-static/01-oidc.yaml
@@ -59,8 +59,10 @@ identity_providers:
         client_secret: {{ env "CONFIG_EXTRA_OIDC_CLIENTS_SPLITPRO_SECRET_FILE" | secret | mindent 8 "|" | msquote }}
         public: false
         authorization_policy: splitpro
-        require_pkce: true
-        pkce_challenge_method: 'S256'
+        # No PKCE, unlike the other clients here: SplitPro builds its NextAuth
+        # provider without `checks: ['pkce']` (src/server/auth.ts), and NextAuth
+        # v4 only does `state` by default, so it never sends a code_challenge.
+        # Requiring it would just break the flow.
         userinfo_signed_response_alg: 'none'
         token_endpoint_auth_method: 'client_secret_basic'
         scopes:


### PR DESCRIPTION
Caught while verifying the bring-up from #164.

I modelled the SplitPro client block on grafana's and carried `require_pkce: true` across without checking whether SplitPro can satisfy it. It can't — it builds its NextAuth provider without `checks: ['pkce']`:

```ts
// src/server/auth.ts
providersList.push({
  id: env.OIDC_NAME?.toLowerCase() ?? 'oidc',
  clientId: env.OIDC_CLIENT_ID,
  clientSecret: env.OIDC_CLIENT_SECRET,
  type: 'oauth',
  wellKnown: env.OIDC_WELL_KNOWN_URL,
  authorization: { params: { scope: 'openid email profile' } },
  idToken: true,
  ...
```

and NextAuth v4 only performs the `state` check unless `checks` says otherwise, so it never sends a `code_challenge`.

Confirmed against the real authorization request rather than inferred — driving `/api/auth/signin/authelia` produces:

```
https://auth.unlimited-code.works/api/oidc/authorization
  client_id             = splitpro
  redirect_uri          = https://split.unlimited-code.works/api/auth/callback/authelia
  scope                 = openid email profile
  response_type         = code
  code_challenge_method = <missing>
```

Authelia doesn't reject that at the authorization endpoint — it still hands back a login flow — so this would not have shown up until someone actually tried to finish a login. Nothing else in the client block changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)