### PR TITLE
fix(hath): move storage off JuiceFS(S3) to a NAS-backed NodePV

### DIFF
--- a/src/hath/index.ts
+++ b/src/hath/index.ts
@@ -8,7 +8,15 @@ import { juicefsColocationAffinity } from "#src/juicefs";
 
 interface HathArgs {
     base: BaseCluster,
-    storageClassName: pulumi.Input<string>,
+    // Storage. Provide exactly one of:
+    //  - storageClassName: dynamically provision the PVC
+    //  - dataPvc: reuse an existing PVC (e.g. a static NodePV on a host path)
+    storageClassName?: pulumi.Input<string>,
+    dataPvc?: kx.PersistentVolumeClaim,
+    // Co-locate with the juicefs-redis master for metadata perf. Only
+    // relevant for a jfs-backed instance; a NodePV-backed pod is already
+    // node-pinned by the PV's nodeAffinity.
+    juicefsColocation?: boolean,
 }
 
 /**
@@ -19,6 +27,10 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
     constructor(name: string, args: HathArgs, opts?: pulumi.ComponentResourceOptions) {
         super('kluster:Hath', name, args, opts);
 
+        if ((args.storageClassName === undefined) === (args.dataPvc === undefined)) {
+            throw new Error("Hath requires exactly one of storageClassName or dataPvc");
+        }
+
         const secrets = new SealedSecret(name, {
             spec: {
                 encryptedData: {
@@ -27,7 +39,7 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
             }
         }, { parent: this });
 
-        const pvc = args.base.createLocalStoragePVC(`${name}`, {
+        const pvc = args.dataPvc ?? args.base.createLocalStoragePVC(`${name}`, {
             storageClassName: args.storageClassName,
             resources: {
                 requests: {
@@ -42,8 +54,9 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
             restartPolicy: 'Always',
             // Hath need to time to shut down gracefully, give it 5min
             terminationGracePeriodSeconds: 300,
-            // Place it close to jfs matadata
-            affinity: juicefsColocationAffinity(),
+            // Place it close to jfs metadata (jfs-backed instance only; a
+            // NodePV-backed pod is already node-pinned by the PV's nodeAffinity).
+            affinity: args.juicefsColocation ? juicefsColocationAffinity() : undefined,
             securityContext: {
                 fsGroup: 1000,
                 fsGroupChangePolicy: 'OnRootMismatch',

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,11 +296,23 @@ function setup() {
         cacheStorageClass: cluster.localStorageClass.metadata.name,
     }, { provider: namespaced('immich') });
 
-    // Hath@Home
+    // Hath@Home. Was jfs-backed (S3), moved to a NAS-backed NodePV pinned to
+    // homelab: the jfs local block cache is shared/too small for hath's
+    // working set, so most serves missed cache and pulled straight from S3
+    // -- the dominant driver of the AWS bill. hath's own footprint
+    // (~50GiB) fits comfortably on the NAS instead.
+    const hathProvider = namespaced('hath');
+    const hathPv = new NodePV('hath-pv', {
+        path: "/mnt/nas/Hath",
+        node: cluster.nodes.AetfArchHomelab,
+        capacity: "60Gi",
+        accessModes: ["ReadWriteOnce"],
+    }, { provider: hathProvider });
     const hath = new Hath('hath', {
         base: cluster,
-        storageClassName: cluster.jfsStorageClass.metadata.name,
-    }, { provider: namespaced('hath') });
+        dataPvc: hathPv.pvc,
+        juicefsColocation: false, // pinned to homelab node by the PV instead
+    }, { provider: hathProvider });
 
     // HaOS
     const haos = new Haos("haos", {


### PR DESCRIPTION
## Why

hath's PVC (`hath-317aa4f9`, 50Gi) is dynamically provisioned on the
JuiceFS storage class, backed by the AWS S3 bucket
`works-unlimited-code-jfs`. Since hath's pod was recreated on 2026-07-22
(CPU limit raised 50m→200m, so it finally passes H@H speed tests and
starts getting real traffic from the network), the local JuiceFS block
cache on `aetf-arch-vps` (49GB disk, shared by 5 volumes) can't hold
hath's ~50GiB working set, so most image serves miss the cache and pull
straight from S3 — ~440GB egress in 11 days, the dominant driver of this
month's AWS bill.

## What

- `src/index.ts`: add a `NodePV('hath-pv', ...)` pointed at
  `/mnt/nas/Hath` on `aetf-arch-homelab` (root disk there is already 83%
  full, `/mnt/nas` has 10.9T free), matching the existing
  `media-pv`/`sync-nas-pv` pattern. Pass it to `Hath` as `dataPvc`.
- `src/hath/index.ts`: `Hath` now takes an optional `dataPvc` (a
  pre-built PVC, e.g. a static NodePV) or `storageClassName` (dynamic
  provisioning) — exactly one required — plus a `juicefsColocation`
  toggle, mirroring the existing `Syncthing` component. Drops the
  hard-coded `juicefsColocationAffinity()` when not jfs-backed, since a
  NodePV-backed pod is already node-pinned by the PV's `nodeAffinity`.

## Rollout (not part of this PR's merge)

Data (`cache/`≈49GiB/310k files) is being pre-copied from the live
JuiceFS mount to `/mnt/nas/Hath` out of band while hath keeps running
normally. This PR is opened early so CI's preview can be reviewed, but
**merge is deliberately held** until the data copy is caught up — the
merge itself is the cutover (deletes the old JuiceFS PVC, creates the
new NodePV/PVC, moves the pod to homelab). See
`~/.claude/plans/hath-local-path-vps-homelab-lazy-mccarthy.md` for the
full plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)