### PR TITLE
Revert "fix(hath): move storage off JuiceFS(S3) to a NAS-backed NodePV"

### DIFF
--- a/src/hath/index.ts
+++ b/src/hath/index.ts
@@ -8,15 +8,7 @@ import { juicefsColocationAffinity } from "#src/juicefs";
 
 interface HathArgs {
     base: BaseCluster,
-    // Storage. Provide exactly one of:
-    //  - storageClassName: dynamically provision the PVC
-    //  - dataPvc: reuse an existing PVC (e.g. a static NodePV on a host path)
-    storageClassName?: pulumi.Input<string>,
-    dataPvc?: kx.PersistentVolumeClaim,
-    // Co-locate with the juicefs-redis master for metadata perf. Only
-    // relevant for a jfs-backed instance; a NodePV-backed pod is already
-    // node-pinned by the PV's nodeAffinity.
-    juicefsColocation?: boolean,
+    storageClassName: pulumi.Input<string>,
 }
 
 /**
@@ -27,10 +19,6 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
     constructor(name: string, args: HathArgs, opts?: pulumi.ComponentResourceOptions) {
         super('kluster:Hath', name, args, opts);
 
-        if ((args.storageClassName === undefined) === (args.dataPvc === undefined)) {
-            throw new Error("Hath requires exactly one of storageClassName or dataPvc");
-        }
-
         const secrets = new SealedSecret(name, {
             spec: {
                 encryptedData: {
@@ -39,7 +27,7 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
             }
         }, { parent: this });
 
-        const pvc = args.dataPvc ?? args.base.createLocalStoragePVC(`${name}`, {
+        const pvc = args.base.createLocalStoragePVC(`${name}`, {
             storageClassName: args.storageClassName,
             resources: {
                 requests: {
@@ -54,9 +42,8 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
             restartPolicy: 'Always',
             // Hath need to time to shut down gracefully, give it 5min
             terminationGracePeriodSeconds: 300,
-            // Place it close to jfs metadata (jfs-backed instance only; a
-            // NodePV-backed pod is already node-pinned by the PV's nodeAffinity).
-            affinity: args.juicefsColocation ? juicefsColocationAffinity() : undefined,
+            // Place it close to jfs matadata
+            affinity: juicefsColocationAffinity(),
             securityContext: {
                 fsGroup: 1000,
                 fsGroupChangePolicy: 'OnRootMismatch',

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,23 +296,11 @@ function setup() {
         cacheStorageClass: cluster.localStorageClass.metadata.name,
     }, { provider: namespaced('immich') });
 
-    // Hath@Home. Was jfs-backed (S3), moved to a NAS-backed NodePV pinned to
-    // homelab: the jfs local block cache is shared/too small for hath's
-    // working set, so most serves missed cache and pulled straight from S3
-    // -- the dominant driver of the AWS bill. hath's own footprint
-    // (~50GiB) fits comfortably on the NAS instead.
-    const hathProvider = namespaced('hath');
-    const hathPv = new NodePV('hath-pv', {
-        path: "/mnt/nas/Hath",
-        node: cluster.nodes.AetfArchHomelab,
-        capacity: "60Gi",
-        accessModes: ["ReadWriteOnce"],
-    }, { provider: hathProvider });
+    // Hath@Home
     const hath = new Hath('hath', {
         base: cluster,
-        dataPvc: hathPv.pvc,
-        juicefsColocation: false, // pinned to homelab node by the PV instead
-    }, { provider: hathProvider });
+        storageClassName: cluster.jfsStorageClass.metadata.name,
+    }, { provider: namespaced('hath') });
 
     // HaOS
     const haos = new Haos("haos", {


### PR DESCRIPTION
## Why

The homelab node's pod egress uses the home ISP's public IP, while hath's
LoadBalancer ingress stays on the vps's public IP (`45.77.144.92`) — the
H@H network requires outgoing and incoming IP to match, so the client
failed its external connectivity test after the pod moved to homelab.
Already rolled back live via a manual kubectl patch to restore service
immediately; this PR brings the Pulumi-managed state back in sync with
that live rollback so the next unrelated deploy doesn't reintroduce the
broken config.

The NAS-copied data (`/mnt/nas/Hath`) and the NodePV code are left in
place/on disk for a future retry once an egress-routing fix (route hath's
pod traffic back out through the vps node) is designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)