### PR TITLE
feat(egress): route hath's egress out through the vps

### DIFF
--- a/Pulumi.dev.yaml
+++ b/Pulumi.dev.yaml
@@ -44,3 +44,4 @@ config:
   image:spoolman: ghcr.io/donkie/spoolman:0.26.0
   image:splitpro: ghcr.io/oss-apps/splitpro:v2.1.5
   image:splitproDb: ghcr.io/aetf/pgcron-cnpg:17.10-standard-trixie-1
+  image:wireguard: ghcr.io/linuxserver/wireguard:1.0.20260223-r0-ls120

--- a/src/egress/index.ts
+++ b/src/egress/index.ts
@@ -1,0 +1,175 @@
+import * as dns from "dns";
+import * as pulumi from "@pulumi/pulumi";
+import * as kx from "@pulumi/kubernetesx";
+
+import { ConfigMap, Node, SealedSecret } from "#src/utils";
+import { versions } from "#src/config";
+
+// k3s defaults, as configured on this cluster.
+const podCidr = '10.42.0.0/16';
+const serviceCidr = '10.43.0.0/16';
+// The ZeroTier network the two nodes are joined over. k3s uses those addresses
+// as the nodes' InternalIP, so it is also what the endpoint host resolves to.
+const underlayCidr = '10.144.0.0/16';
+
+// A /30 that exists only inside the tunnel.
+const gatewayAddress = '10.210.0.1';
+const clientAddress = '10.210.0.2';
+const tunnelSubnet = '10.210.0.0/30';
+const prefixLength = 30;
+
+const port = 51820;
+// The usual WireGuard-over-1500 figure. eth0 on both ends is 2800 (ZeroTier),
+// but the hop past the gateway is a plain internet path, so size for that one.
+const mtu = 1420;
+
+const scriptPath = '/opt/egress';
+const gatewayKeyPath = '/etc/wireguard/gateway.key';
+const clientKeyPath = '/etc/wireguard/client.key';
+
+// The private halves live in the SealedSecret below.
+const gatewayPublicKey = '8Y0VA/JbXsPq5mIfZtrwRVM78p7UZGofY+FERBvXmHk=';
+const clientPublicKey = 'tRjfWciQaPwJ3oi3cOPBiWnQzEc/OhEq2msqbq4lPWU=';
+
+export interface EgressGatewayArgs {
+    /** Node whose public IP outbound traffic should appear to come from. */
+    node: Node,
+    /** Name resolving to `node`'s address on the underlay network. */
+    endpointHost: pulumi.Input<string>,
+}
+
+/**
+ * Routes one pod's egress out through another node.
+ *
+ * A pod's outbound traffic is masqueraded to whichever node it happens to run
+ * on, which is a problem for anything whose peers expect a fixed source address
+ * -- hath, whose inbound LoadBalancer sits on the vps while its data lives on
+ * homelab, being the case this was built for.
+ *
+ * The gateway is a pod pinned to `node`, terminating a WireGuard tunnel and
+ * NATing what comes out of it to its own eth0. Since it is an ordinary pod,
+ * flannel then masquerades that to `node`'s public address -- so the source IP
+ * falls out of where the gateway pod is scheduled, with no host-level rule and
+ * no root on either machine.
+ *
+ * Clients opt in with `clientInitContainer()`, which rewrites the default route
+ * in their own network namespace. That is what keeps this per-pod: a route or
+ * policy on the host would apply to every pod on the node.
+ *
+ * Clients must be in the same namespace, as they mount the key material here.
+ */
+export class EgressGateway extends pulumi.ComponentResource<EgressGatewayArgs> {
+    private readonly secret: SealedSecret;
+    private readonly scripts: ConfigMap;
+
+    constructor(name: string, args: EgressGatewayArgs, opts?: pulumi.ComponentResourceOptions) {
+        super('kluster:EgressGateway', name, args, opts);
+
+        // Resolved at eval time, the same way haos reaches across the tunnel.
+        const endpointIP = pulumi.output(args.endpointHost).apply(async host => {
+            const result = await dns.promises.lookup(host);
+            return result.address;
+        });
+
+        this.secret = new SealedSecret(name, {
+            spec: {
+                encryptedData: {
+                    gateway_privkey: "AgAemfOCHegIC9qdcPZx68OpGYBhhREsgv8WAARQAK7enFAZzzEZweI1gK2FixoLwnI7Byn1WXoxp4olofPmdR9bUAWvf/bDdyx8tTDUEjQHIPITuGIPrhH+W+GlpaSDoMFLiZw27soEtHtkDzxdYuYyQX6jSuPiFmwu/L1z0hfjWh2cdnOmIiTTOOhQpdPidQJtoQ4a6ziw/uhOHz8WKUkGLJegTH5Te/eNRsuwXGY2TU7QWUbv7W6ucBmpPsPxJ8DpOoXKDC/sV7VowGLsonBh3Qeo/1Mp+iyDXFI0gzh7UPlJFFa6wLzpsfXYYi+Wyaug41AwowbOkX73KbVuInpK+JbUIXFsMlseU3KafFEQOWMwEVtfbDRdGp9O6cgq7JdYET7XoS2rHSFxxMsvJpp/OKQTWc72DRGs00aNFUlnJvhHQzdlb+AZRB4rJRq8ZC+c3f1JiSJ4/9FW+JSt5RZK/4R+s26D8bq4PGCuCoHsx9G3DOKYFWvBNR1iBbNu3+mec/NqwBKaY+K3sUTL0YBzFgdj4GTlSosBusuoGRoGnIB8qdx3+CZ6r68N/Ij398rB+DzOy3Ma+lei4S8JWJ51YdKCRLaS5Dz8/4oJYzAWQ4/GzpjczWseKQJHGVmuo2Ni/MQfJ/3dKmCv+IYXKaKfXxfRJRCE1VAnICUzEGfG6tB6GGF6CTtIV4Qc6S9ZcoKFENNVSRpOxf1GBL483RhTRfk/vnUDJqB/7AvA5sKi3UEP6P24bvleDNm/lw==",
+                    client_privkey: "AgCwOVsa911WHM33q0PKXfH2CN8hUA14Olq4YseHvW3iK2tyF+RUX/WOPIAnD9qpXKNZYv9tQQMzUEAA/RSjjJXnyfpW1VcIN+Efz++AVex+m+RodHGobi8QBaFlFf4eYlreqYt3OfeQw2pR51pY5IP59Lefo+vVpJXkWffNWtSeT3hFRTNmNP+JMhpzFYwEOVtkGB4mpBISnCaPUH6cju18ovAZwK5R2AwHnDCEpX4sBS1ThQq6FgwJ+KjJlAru94o91Y7HomkCiG05PquzzTm0qV3+7KlHk5um86GPLG7vIk+e6wXIzUw3vQQAhoRXK91/CFjaWbi4Nm7cn6XfpLYDdqds0EXH9yuN1WKJTGI3H/h1peLNaI5gQC5svKlUi+S2q2/3dh1xmyO/qXogA9KL2mbke10uGGuzvA7c+RXHjbAkKhUsojQXzRyTQrcdfPVU3dZLvpc7MCDdwQf42eBx4DZ53yRlqjMQJ3ZBpu2QFCZbaFy8xsF+kG8Qtt5qwJM2RVLbBsZQSRW48jfvXXxuidxpDl74xsjPrcFnvOj7s84qq3GzuaIsC7eGQnFsma6RUnzdkhydM2O6GLYS8GUmLEFWsY8pMJYSb0g5E2K8uCuEwmyDbFU8RinwOLeSQ95rszCIBvsUgt2sV/hFs8Qv5ZwklQ1WDuAPqIEKT73hJNwKwiMu/aX6jSy2EZCCjbT7SRfLHXQjt4FJPWqCu7a90gEb6cZUgEgQZAt8fV4yCyNNQdhmsqr4z1M+3w==",
+                }
+            }
+        }, { parent: this });
+
+        this.scripts = new ConfigMap(name, {
+            ref_file: __filename,
+            data: 'static/*',
+            stripComponents: 1,
+            tplVariables: {
+                podCidr, serviceCidr, underlayCidr,
+                gatewayAddress, clientAddress, tunnelSubnet, prefixLength,
+                port, mtu,
+                gatewayKeyPath, clientKeyPath,
+                gatewayPublicKey, clientPublicKey,
+                endpoint: pulumi.interpolate`${endpointIP}:${port}`,
+            }
+        }, { parent: this });
+
+        const pb = new kx.PodBuilder({
+            restartPolicy: 'Always',
+            nodeSelector: args.node.hostnameSelectorLabels,
+            securityContext: {
+                // Namespaced and, since k8s 1.29, a safe sysctl -- the svclb
+                // pods this cluster already runs set it the same way.
+                sysctls: [{ name: 'net.ipv4.ip_forward', value: '1' }],
+            },
+            containers: [{
+                name,
+                image: versions.image.wireguard,
+                // Skip the image's s6 entrypoint, we only want its tools.
+                command: ['/bin/sh', `${scriptPath}/gateway.sh`],
+                resources: {
+                    requests: { cpu: "10m", memory: "32Mi" },
+                    limits: { cpu: "500m", memory: "128Mi" },
+                },
+                ports: [{
+                    name: 'wireguard',
+                    protocol: 'UDP',
+                    containerPort: port,
+                    hostPort: port,
+                    // Bind to the underlay only, so the endpoint isn't also
+                    // listening on the node's public address.
+                    hostIP: endpointIP,
+                }],
+                securityContext: {
+                    capabilities: {
+                        add: ['NET_ADMIN'],
+                    }
+                },
+                volumeMounts: [
+                    this.scripts.mount(scriptPath),
+                    this.secret.mount(gatewayKeyPath, 'gateway_privkey'),
+                ],
+            }],
+        });
+
+        new kx.Deployment(name, {
+            metadata: {
+                annotations: {
+                    "reloader.stakater.com/auto": "true"
+                }
+            },
+            spec: pb.asDeploymentSpec(),
+        }, { parent: this });
+
+        this.registerOutputs({});
+    }
+
+    /**
+     * Init container replacing the enclosing pod's default route with this
+     * gateway. Needs NET_ADMIN; the app container itself needs nothing.
+     *
+     * Deliberately an init container and not a sidecar: kernel WireGuard is
+     * state in the network namespace, not a process, so there is nothing left
+     * to keep running once it is set up.
+     */
+    public clientInitContainer(name: string): pulumi.Input<kx.types.Container> {
+        return {
+            name,
+            image: versions.image.wireguard,
+            command: ['/bin/sh', `${scriptPath}/client.sh`],
+            securityContext: {
+                capabilities: {
+                    add: ['NET_ADMIN'],
+                }
+            },
+            volumeMounts: [
+                this.scripts.mount(scriptPath),
+                this.secret.mount(clientKeyPath, 'client_privkey'),
+            ],
+        };
+    }
+
+    protected async initialize(args: pulumi.Inputs): Promise<EgressGatewayArgs> {
+        return args as EgressGatewayArgs;
+    }
+}

--- a/src/egress/static/client.sh
+++ b/src/egress/static/client.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Point this pod's default route at the egress gateway, so its outbound traffic
+# leaves from the gateway node's public IP instead of its own node's.
+#
+# Runs as an init container: kernel WireGuard needs no daemon, so once the link
+# is configured it lives as long as the pod's network namespace does.
+#
+# Only the default route moves. These three keep going out eth0, and getting
+# them wrong is how this breaks:
+#   - pod CIDR:     inbound replies. klipper-lb masquerades, so the peer we
+#                   answer is the svclb pod, not the real client -- those
+#                   replies must not enter the tunnel or they'd never get back.
+#   - service CIDR: cluster DNS and every ClusterIP. The CNI installs only the
+#                   pod CIDR plus a default route, so without this line the
+#                   tunnel swallows DNS.
+#   - underlay:     carries the WireGuard endpoint itself. Circular otherwise.
+set -eu
+
+gw=$(ip -4 route show default | awk '{ print $3; exit }')
+uplink=$(ip -4 route show default | awk '{ print $5; exit }')
+[ -n "$gw" ] && [ -n "$uplink" ] || {
+    echo "no default route to anchor the cluster prefixes on" >&2
+    exit 1
+}
+
+for cidr in {{{podCidr}}} {{{serviceCidr}}} {{{underlayCidr}}}; do
+    ip route replace "$cidr" via "$gw" dev "$uplink"
+done
+
+ip link add wg0 type wireguard
+
+umask 077
+conf=$(mktemp)
+cat > "$conf" <<EOF
+[Interface]
+PrivateKey = $(cat {{{clientKeyPath}}})
+
+[Peer]
+PublicKey = {{{gatewayPublicKey}}}
+Endpoint = {{{endpoint}}}
+AllowedIPs = 0.0.0.0/0
+# Keeps the conntrack entry for our outbound handshake alive, so the gateway
+# can still reach us after it has been restarted or rescheduled.
+PersistentKeepalive = 25
+EOF
+wg setconf wg0 "$conf"
+rm -f "$conf"
+
+ip address add {{{clientAddress}}}/{{{prefixLength}}} dev wg0
+ip link set wg0 mtu {{{mtu}}} up
+
+# Fail closed, in two senses. With `set -e` a pod that cannot get this far never
+# starts; and dropping the node-local default leaves nothing to silently fall
+# back to should wg0 ever disappear. Going out of the local node's address is
+# the exact bug being fixed here, so no route at all beats the wrong source
+# address -- and a stalled hath is much easier to notice than a quietly
+# mis-addressed one.
+ip route replace default dev wg0
+ip route del default via "$gw" dev "$uplink"

--- a/src/egress/static/gateway.sh
+++ b/src/egress/static/gateway.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# WireGuard endpoint for the egress gateway.
+#
+# Everything arriving over the tunnel is NATed out of this pod's uplink. It
+# is pinned to the gateway node, and flannel already masquerades pod traffic to
+# that node's default-route source address, so packets surface on the internet
+# with the node's public IP. That second SNAT is the whole trick: it is why
+# neither this pod nor either host needs root or a host-level rule.
+set -eu
+
+uplink=$(ip -4 route show default | awk '{ print $5; exit }')
+[ -n "$uplink" ] || { echo "no default route to NAT out of" >&2; exit 1; }
+
+ip link add wg0 type wireguard
+
+umask 077
+conf=$(mktemp)
+cat > "$conf" <<EOF
+[Interface]
+PrivateKey = $(cat {{{gatewayKeyPath}}})
+ListenPort = {{{port}}}
+
+[Peer]
+PublicKey = {{{clientPublicKey}}}
+AllowedIPs = {{{clientAddress}}}/32
+EOF
+wg setconf wg0 "$conf"
+rm -f "$conf"
+
+ip address add {{{gatewayAddress}}}/{{{prefixLength}}} dev wg0
+ip link set wg0 mtu {{{mtu}}} up
+
+iptables -t nat -A POSTROUTING -s {{{tunnelSubnet}}} -o "$uplink" -j MASQUERADE
+# The tunnel MTU is well under eth0's, but the leg past this pod is a plain
+# 1500 internet path. Clamp forwarded SYNs so we don't depend on PMTUD
+# surviving a peer that blackholes ICMP.
+iptables -t mangle -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+exec sleep infinity

--- a/src/hath/index.ts
+++ b/src/hath/index.ts
@@ -5,10 +5,19 @@ import { BaseCluster } from '#src/base-cluster';
 import { SealedSecret, serviceFromDeployment } from "#src/utils";
 import { versions } from "#src/config";
 import { juicefsColocationAffinity } from "#src/juicefs";
+import { EgressGateway } from "#src/egress";
 
 interface HathArgs {
     base: BaseCluster,
     storageClassName: pulumi.Input<string>,
+    /**
+     * Send outbound traffic through this gateway. H@H takes the source address
+     * of the client's outbound RPC as its public identity and then connect
+     * tests it, so egress has to come from the same IP the LoadBalancer is on
+     * -- otherwise the pod fails FAIL_CONNECT_TEST as soon as it is scheduled
+     * anywhere but the node holding that IP.
+     */
+    egress?: EgressGateway,
 }
 
 /**
@@ -48,6 +57,7 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
                 fsGroup: 1000,
                 fsGroupChangePolicy: 'OnRootMismatch',
             },
+            initContainers: args.egress ? [args.egress.clientInitContainer(`${name}-egress`)] : undefined,
             containers: [{
                 name,
                 image: versions.image.hath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { Shoko } from "./shoko";
 import { Dufs } from "./dav";
 import { CloudNativePg } from "./postgresql";
 import { Immich } from "./immich";
+import { EgressGateway } from "./egress";
 import { Hath } from "./hath";
 import { SealedSecret, Service } from "./utils";
 import { Spoolman } from "./spoolman";
@@ -296,11 +297,19 @@ function setup() {
         cacheStorageClass: cluster.localStorageClass.metadata.name,
     }, { provider: namespaced('immich') });
 
-    // Hath@Home
+    // Hath@Home. Its public identity is the vps IP its LoadBalancer sits on,
+    // so it egresses through the vps too -- which is what lets the pod be
+    // scheduled on homelab, next to a disk big enough for its cache.
+    const hathProvider = namespaced('hath');
+    const hathEgress = new EgressGateway('hath-egress', {
+        node: cluster.nodes.AetfArchVPS,
+        endpointHost: 'aetf-arch-vps.zt.unlimited-code.works',
+    }, { provider: hathProvider });
     const hath = new Hath('hath', {
         base: cluster,
         storageClassName: cluster.jfsStorageClass.metadata.name,
-    }, { provider: namespaced('hath') });
+        egress: hathEgress,
+    }, { provider: hathProvider });
 
     // HaOS
     const haos = new Haos("haos", {

--- a/src/splitpro/index.ts
+++ b/src/splitpro/index.ts
@@ -2,15 +2,10 @@ import * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
 import * as kx from "@pulumi/kubernetesx";
 
-import { NamespaceProbe, Node, SealedSecret, serviceFromDeployment } from "#src/utils";
+import { NamespaceProbe, SealedSecret, serviceFromDeployment } from "#src/utils";
 import { Serving } from "#src/serving";
 import * as crds from "#src/crds";
 import { versions } from "#src/config";
-
-/** nodeSelector pinning a pod to one specific node. */
-function nodeHostname(node: Node): Record<string, pulumi.Output<string>> {
-    return { 'kubernetes.io/hostname': pulumi.output(node.metadata).apply(md => md.name!) };
-}
 
 /**
  * Opt-in: S3-compatible object storage is *not* used -- SplitPro keeps receipts
@@ -200,7 +195,7 @@ export class Splitpro extends pulumi.ComponentResource<SplitproArgs> {
             // homelab: the VPS is the tight node (57% cpu / 53% memory
             // requested, against 7% / 15% here) and it has nothing this app
             // needs.
-            nodeSelector: nodeHostname(args.serving.base.nodes.AetfArchHomelab),
+            nodeSelector: args.serving.base.nodes.AetfArchHomelab.hostnameSelectorLabels,
         });
 
         const deployment = new kx.Deployment(name, {
@@ -333,7 +328,7 @@ export class Splitpro extends pulumi.ComponentResource<SplitproArgs> {
                 // Retain policy, so it has to be pinned, and the homelab is the
                 // node with room.
                 affinity: {
-                    nodeSelector: nodeHostname(serving.base.nodes.AetfArchHomelab),
+                    nodeSelector: serving.base.nodes.AetfArchHomelab.hostnameSelectorLabels,
                 },
                 imageName: versions.image.splitproDb,
                 postgresql: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -430,11 +430,16 @@ declare module '@pulumi/kubernetes/core/v1/nodePatch' {
          * Selector to uniquely select this node
          */
         readonly hostnameSelector: k8s.types.input.core.v1.NodeSelectorTerm;
+        /**
+         * `nodeSelector` map pinning a pod to this node. The blunter sibling of
+         * `hostnameSelector`, for the places that take a plain label map.
+         */
+        readonly hostnameSelectorLabels: Record<string, pulumi.Output<string>>;
     }
 }
+const hostnamelabel = 'kubernetes.io/hostname';
 Object.defineProperty(NodePatch.prototype, 'hostnameSelector', {
     get: function(): k8s.types.input.core.v1.NodeSelectorTerm {
-        const hostnamelabel = 'kubernetes.io/hostname';
         return {
             matchExpressions: [{
                 key: hostnamelabel,
@@ -442,5 +447,11 @@ Object.defineProperty(NodePatch.prototype, 'hostnameSelector', {
                 values: [this.metadata.name],
             }],
         };
+    }
+});
+Object.defineProperty(NodePatch.prototype, 'hostnameSelectorLabels', {
+    get: function(this: NodePatch): Record<string, pulumi.Output<string>> {
+        const name: pulumi.Output<string> = this.metadata.apply(md => md.name!);
+        return { [hostnamelabel]: name };
     }
 });


### PR DESCRIPTION
## Why

hath's public identity on the H@H network is **the source address of its own outbound RPC**, which the H@H servers then connect test. Its LoadBalancer is pinned to the vps (`lbpool: internet`), but a pod egresses via whatever node it runs on — so [#170](https://github.com/Aetf/kluster-code/pull/170)'s move to homelab (where there is a disk big enough for the 50GiB cache, instead of thrashing the shared JuiceFS block cache and driving ~440GB/11d of S3 egress) failed `FAIL_CONNECT_TEST` and had to be reverted in cda0d21.

This is the egress fix that #171 said was still to be designed. The storage move relands in a follow-up PR.

## How

An `EgressGateway` component: a pod pinned to the vps terminating a WireGuard tunnel and NATing what comes out of it to its own uplink. Because it is an *ordinary* pod, flannel then masquerades that to the vps's public address — so the egress IP falls out of where the gateway pod is scheduled, and **no host on either end needs a route, an iptables rule, or root** (we have neither root nor aconfmgr on the vps). Clients opt in via an init container that rewrites the default route inside their own netns, which is what keeps this scoped to one pod rather than the whole node.

Why a tunnel at all, given ZeroTier already joins the two nodes: ZeroTier solves host↔host reachability and this rides *on top of* it. What it cannot do is per-pod policy — a route or `ip rule` on the host applies to every pod on the node, and hath's neighbours (traefik, immich, splitpro, …) must keep egressing from home. The only place a per-pod decision can be made is inside hath's own netns, and getting packets out of that netns toward the vps means encapsulating.

Why WireGuard specifically, given the underlay is already encrypted: it is the only cheap tunnel that tolerates a **dynamic initiator address**. The responder learns the client's endpoint from the handshake, so nothing has to track hath's pod IP across restarts; GRE and VXLAN want a static remote at both ends and would need fdb learning to cope. It also needs only `NET_ADMIN` — kernel WireGuard, so no `/dev/net/tun` and nothing privileged.

Upstream alternatives were considered: Cilium's egress gateway means replacing flannel cluster-wide for one pod, and `spidernet-io/egressgateway` — the one genuinely CNI-agnostic fit, and architecturally the generalised version of this — costs a chart, CRDs, a controller and a privileged DaemonSet on every node permanently, plus a third encapsulation layer, with its VXLAN over ZeroTier+host-gw untested. If a second app ever needs this, that is the right thing to refactor into; this is a strict subset of it.

## Blast radius

**Inert on merge.** hath is still on the vps, so the gateway lands on the same node and the egress IP is 45.77.144.92 either way — H@H cannot tell the difference. That is the point of splitting the PR: it lets the tunnel be verified before the storage move depends on it.

The one real risk is availability, not identity: hath restarts to pick up the init container, and the init container is fail-closed (`set -e`, and it deletes the node-local default route so there is nothing to silently leak back to). If it does not come up, hath is down until reverted.

Both scripts were run end-to-end in a container with only `NET_ADMIN` before this was opened: wg0 comes up, the peer and addresses configure, the NAT and MSS-clamp rules land, and the client ends with exactly one default route pointing at wg0 with the pod/service/ZeroTier prefixes preserved on the uplink. That test also confirmed `ip link add type wireguard` autoloads the module from inside a netns — it was not loaded on the host beforehand.

## Verification after merge

- gateway pod Running on `aetf-arch-vps`, hath Running
- `kubectl -n hath exec deploy/hath-egress -- wg show` shows a recent handshake and two-way transfer
- `kubectl debug -n hath <hath-pod> --image=curlimages/curl -- curl -s https://ifconfig.me` → `45.77.144.92` (ephemeral containers share the pod netns, so this is hath's real egress path)
- DNS still resolves from that same debug container
- hath logs free of `FAIL_*`, and `45.77.144.92:60011` still reachable from outside

🤖 Generated with [Claude Code](https://claude.com/claude-code)
