### PR TITLE
fix(egress): make the tunnel setup survive a container restart

### DIFF
--- a/src/egress/static/client.sh
+++ b/src/egress/static/client.sh
@@ -16,6 +16,12 @@
 #   - underlay:     carries the WireGuard endpoint itself. Circular otherwise.
 set -eu
 
+# Re-runnable. A restarted init container comes back to a namespace it has
+# already configured, so drop the interface first -- which also takes the routes
+# hanging off it, leaving the lookup below to find the CNI's default route
+# rather than one of ours.
+ip link del wg0 2>/dev/null || true
+
 gw=$(ip -4 route show default | awk '{ print $3; exit }')
 uplink=$(ip -4 route show default | awk '{ print $5; exit }')
 [ -n "$gw" ] && [ -n "$uplink" ] || {
@@ -49,11 +55,11 @@ rm -f "$conf"
 ip address add {{{clientAddress}}}/{{{prefixLength}}} dev wg0
 ip link set wg0 mtu {{{mtu}}} up
 
-# Fail closed, in two senses. With `set -e` a pod that cannot get this far never
-# starts; and dropping the node-local default leaves nothing to silently fall
-# back to should wg0 ever disappear. Going out of the local node's address is
-# the exact bug being fixed here, so no route at all beats the wrong source
-# address -- and a stalled hath is much easier to notice than a quietly
-# mis-addressed one.
-ip route replace default dev wg0
-ip route del default via "$gw" dev "$uplink"
+# Two halves of the address space rather than a default route, the way wg-quick
+# does it. They beat the CNI's default by being more specific, without replacing
+# it -- and leaving it in place is what lets a re-run of this script rediscover
+# the uplink. (Replacing it does not work anyway: it carries the same metric, so
+# `ip route replace default dev wg0` substitutes it outright rather than adding
+# a second route.)
+ip route replace 0.0.0.0/1 dev wg0
+ip route replace 128.0.0.0/1 dev wg0

--- a/src/egress/static/gateway.sh
+++ b/src/egress/static/gateway.sh
@@ -8,6 +8,16 @@
 # neither this pod nor either host needs root or a host-level rule.
 set -eu
 
+# Re-runnable: a restarted container comes back to a namespace it has already
+# configured, and every step below would otherwise fail on its own leftovers.
+ip link del wg0 2>/dev/null || true
+ensure() {
+    table=$1 chain=$2
+    shift 2
+    iptables -t "$table" -C "$chain" "$@" 2>/dev/null \
+        || iptables -t "$table" -A "$chain" "$@"
+}
+
 uplink=$(ip -4 route show default | awk '{ print $5; exit }')
 [ -n "$uplink" ] || { echo "no default route to NAT out of" >&2; exit 1; }
 
@@ -30,10 +40,10 @@ rm -f "$conf"
 ip address add {{{gatewayAddress}}}/{{{prefixLength}}} dev wg0
 ip link set wg0 mtu {{{mtu}}} up
 
-iptables -t nat -A POSTROUTING -s {{{tunnelSubnet}}} -o "$uplink" -j MASQUERADE
-# The tunnel MTU is well under eth0's, but the leg past this pod is a plain
-# 1500 internet path. Clamp forwarded SYNs so we don't depend on PMTUD
+ensure nat POSTROUTING -s {{{tunnelSubnet}}} -o "$uplink" -j MASQUERADE
+# The tunnel MTU is well under the uplink's, but the leg past this pod is a
+# plain 1500 internet path. Clamp forwarded SYNs so we don't depend on PMTUD
 # surviving a peer that blackholes ICMP.
-iptables -t mangle -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+ensure mangle FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
 exec sleep infinity


### PR DESCRIPTION
Follow-up to #172, which is currently stuck: hath's init container crash-loops, so the Deployment cannot roll forward. The old hath pod is still Running and serving — `45.77.144.92:60011` is up throughout — so this is a stalled rollout, not an outage.

## What actually happened

The init container **succeeded at its job** and then failed anyway.

In a real pod the CNI's default route (`default via 10.42.0.1 dev eth0`) carries the same metric as the one we install, so `ip route replace default dev wg0` *substituted* it rather than adding a second route. The next line, `ip route del default via "$gw" dev "$uplink"`, then had nothing to delete → non-zero exit → `set -e` → failed init container.

Kubernetes re-ran it **in the namespace it had already configured**, where `ip -4 route show default` now reads `default dev wg0 scope link`. The awk that expects `default via GW dev DEV` picked `gw=wg0`, `uplink=link`, so the retry died on `ip route replace 10.42.0.0/16 via wg0 dev link` — the `inet address is expected rather than "wg0"` in the logs.

Confirmed by inspecting the stuck pod's netns with an ephemeral container: the routes are exactly the intended end state, which is what gave the first-run-succeeded diagnosis.

**Why the pre-merge smoke test missed it:** it ran the script once, in a namespace whose default route came with `metric 10`. Different route key, so `replace` *added* rather than substituted, and the `del` found its target. The two things that mattered — a metric-0 default, and running twice — were both absent.

## Fix

Install `0.0.0.0/1` and `128.0.0.0/1` instead of a default route, the way `wg-quick` does. They are more specific than the CNI's default so they win without replacing it, and leaving it in place is precisely what lets a re-run rediscover the uplink. Both scripts now start by dropping `wg0`, and the gateway's iptables rules go through a `-C || -A` helper, so a restart converges instead of compounding.

This gives up the fail-closed property the deleted default route was there for. That was worth little — a vanished `wg0` means hath fails its H@H connect test and `check-hath.timer` notices within 15 minutes — and it cost a stuck rollout.

## Verified before opening

Both scripts run **three times** in one namespace, against a reshaped **metric-0** default route (i.e. the shape that broke it), all three succeeding and converging: no duplicate iptables rules, wg0 correct, cluster prefixes intact.

Route *selection* checked with `ip route get`:

| destination | picks |
|---|---|
| `1.1.1.1` (internet) | **`dev wg0 src 10.210.0.2`** |
| `10.43.0.10` (cluster DNS) | uplink |
| `10.42.0.57` (svclb peer — inbound replies) | uplink |
| `10.144.160.212` (wg endpoint) | uplink |

🤖 Generated with [Claude Code](https://claude.com/claude-code)