### PR TITLE
fix(egress): give the gateway a Recreate rollout strategy

### DIFF
--- a/src/egress/index.ts
+++ b/src/egress/index.ts
@@ -138,7 +138,13 @@ export class EgressGateway extends pulumi.ComponentResource<EgressGatewayArgs> {
                     "reloader.stakater.com/auto": "true"
                 }
             },
-            spec: pb.asDeploymentSpec(),
+            // Recreate, not the default RollingUpdate: the hostPort below can
+            // only be held by one pod per node, so a surge replica would sit
+            // Pending on "didn't have free ports" while the rollout waits for
+            // it to go Ready -- a deadlock. Take the old pod down first and
+            // accept a few seconds without a tunnel; WireGuard re-handshakes on
+            // its own and clients keep their routes across the gap.
+            spec: pb.asDeploymentSpec({ strategy: { type: 'Recreate' } }),
         }, { parent: this });
 
         this.registerOutputs({});


### PR DESCRIPTION
Third and last of the #172 follow-ups. Caught while verifying #173: the tunnel itself works, but the gateway Deployment cannot roll.

## The deadlock

The gateway binds a `hostPort`, and only one pod per node can hold it. Under the default `RollingUpdate` the surge replica sits Pending —

```
0/2 nodes are available: 1 node(s) didn't have free ports for the requested pod ports,
1 node(s) didn't match Pod's node affinity/selector.
```

— while the rollout waits for it to become Ready, so the old pod holding the port is never taken down. Left alone this times out the deploy, exactly as the previous rollout did for a different reason.

`Recreate` instead. The cost is a few seconds with no tunnel during an update: WireGuard re-handshakes on its own, and clients keep their routes across the gap because those live in their own netns, not in the gateway.

## State of #172 as of this PR

The mechanism itself is confirmed working end to end, with hath still on the vps:

| check | result |
|---|---|
| egress IP from inside hath's netns | **`45.77.144.92`** |
| `ip route get 1.1.1.1` | `dev wg0 src 10.210.0.2` |
| `ip route get 10.43.0.10` (cluster DNS) | `via 10.42.0.1 dev eth0` |
| WireGuard handshake | 1m ago, 12 KiB in / 88 KiB out |
| inbound `45.77.144.92:60011` | up, and never went down through any of this |

The currently-serving gateway pod is the pre-#173 one — it still holds the hostPort — so this PR is what lets the fixed scripts actually take effect on the gateway side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)