### PR TITLE
fix(hath): move storage off JuiceFS(S3) to a NAS-backed NodePV

### DIFF
--- a/src/hath/index.ts
+++ b/src/hath/index.ts
@@ -9,7 +9,15 @@ import { EgressGateway } from "#src/egress";
 
 interface HathArgs {
     base: BaseCluster,
-    storageClassName: pulumi.Input<string>,
+    // Storage. Provide exactly one of:
+    //  - storageClassName: dynamically provision the PVC
+    //  - dataPvc: reuse an existing PVC (e.g. a static NodePV on a host path)
+    storageClassName?: pulumi.Input<string>,
+    dataPvc?: kx.PersistentVolumeClaim,
+    // Co-locate with the juicefs-redis master for metadata perf. Only
+    // relevant for a jfs-backed instance; a NodePV-backed pod is already
+    // node-pinned by the PV's nodeAffinity.
+    juicefsColocation?: boolean,
     /**
      * Send outbound traffic through this gateway. H@H takes the source address
      * of the client's outbound RPC as its public identity and then connect
@@ -28,6 +36,10 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
     constructor(name: string, args: HathArgs, opts?: pulumi.ComponentResourceOptions) {
         super('kluster:Hath', name, args, opts);
 
+        if ((args.storageClassName === undefined) === (args.dataPvc === undefined)) {
+            throw new Error("Hath requires exactly one of storageClassName or dataPvc");
+        }
+
         const secrets = new SealedSecret(name, {
             spec: {
                 encryptedData: {
@@ -36,7 +48,7 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
             }
         }, { parent: this });
 
-        const pvc = args.base.createLocalStoragePVC(`${name}`, {
+        const pvc = args.dataPvc ?? args.base.createLocalStoragePVC(`${name}`, {
             storageClassName: args.storageClassName,
             resources: {
                 requests: {
@@ -51,8 +63,9 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
             restartPolicy: 'Always',
             // Hath need to time to shut down gracefully, give it 5min
             terminationGracePeriodSeconds: 300,
-            // Place it close to jfs matadata
-            affinity: juicefsColocationAffinity(),
+            // Place it close to jfs metadata (jfs-backed instance only; a
+            // NodePV-backed pod is already node-pinned by the PV's nodeAffinity).
+            affinity: args.juicefsColocation ? juicefsColocationAffinity() : undefined,
             securityContext: {
                 fsGroup: 1000,
                 fsGroupChangePolicy: 'OnRootMismatch',
@@ -110,7 +123,13 @@ export class Hath extends pulumi.ComponentResource<HathArgs> {
                     "reloader.stakater.com/auto": "true"
                 }
             },
-            spec: pb.asDeploymentSpec(),
+            // Recreate, not the default RollingUpdate. A surge replica would be
+            // a second H@H client live on the same client ID -- and when the
+            // storage moved off jfs it would also have been on the other node,
+            // serving a stale copy of the cache. Take the old pod down first;
+            // hath is a single instance either way, so a rolling update buys
+            // nothing.
+            spec: pb.asDeploymentSpec({ strategy: { type: 'Recreate' } }),
         }, { parent: this });
         const service = serviceFromDeployment(name, deployment, {
             metadata: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,9 +305,20 @@ function setup() {
         node: cluster.nodes.AetfArchVPS,
         endpointHost: 'aetf-arch-vps.zt.unlimited-code.works',
     }, { provider: hathProvider });
+    // Storage was jfs-backed (S3) until the jfs local block cache, shared and
+    // far smaller than hath's ~50GiB working set, turned most image serves into
+    // an S3 GetObject -- the dominant driver of the AWS bill. Moved to a
+    // NAS-backed NodePV, following media-pv/sync-nas-pv.
+    const hathPv = new NodePV('hath-pv', {
+        path: "/mnt/nas/Hath",
+        node: cluster.nodes.AetfArchHomelab,
+        capacity: "60Gi",
+        accessModes: ["ReadWriteOnce"],
+    }, { provider: hathProvider });
     const hath = new Hath('hath', {
         base: cluster,
-        storageClassName: cluster.jfsStorageClass.metadata.name,
+        dataPvc: hathPv.pvc,
+        juicefsColocation: false, // pinned to homelab by the PV instead
         egress: hathEgress,
     }, { provider: hathProvider });
 


### PR DESCRIPTION
Reland of #170 (reverted in #171). The egress fix it was waiting on landed in #172/#173/#174 and has been running for hours.

## Why

hath's jfs-backed PVC shares the vps's 49GB local block cache with four other volumes, far smaller than hath's own ~50GiB working set. Since the pod was recreated on 2026-07-22 — CPU limit raised, so it finally passes H@H speed tests and gets real traffic — most image serves miss that cache and pull straight from S3: **~440GB egress in 11 days**, the dominant driver of last month's AWS bill.

hath's data fits comfortably on local disk. Move it to a NAS-backed `NodePV` pinned to `aetf-arch-homelab` (root disk there is 83% full; `/mnt/nas` has 10.9T free), the same pattern as `media-pv`/`sync-nas-pv`.

## Why it can land this time

#171 reverted it because a pod on homelab egressed from the home ISP address while its LoadBalancer stayed on the vps, so H@H's connect test failed. #172 routes hath's egress back out through the vps; confirmed live, and stable for hours since:

- egress IP seen from inside hath's own netns: **`45.77.144.92`**
- hath and gateway pods: no restarts, tunnel handshaking, `45.77.144.92:60011` up

## Also: Recreate rollout

Under the default RollingUpdate the surge replica would be a **second H@H client live on the same client ID** — and across this particular change it would also have been on the other node, serving a stale copy of the cache. hath is a single instance either way, so a rolling update buys nothing.

## Data

`/mnt/nas/Hath` was populated during #170 and kept. Re-synced against the live JuiceFS mount before merging; the bulk was already there, so the delta is minutes, not hours:

```
Number of files: 310,124        Total file size: 52.9 GB
created: 210    deleted: 215    regular files transferred: 730 (~107 MB)
```

A final pass runs immediately before merge, and the old jfs PVC is `pulumi unprotect`ed so this deploy can drop it from state. It is `retainOnDelete`, so the PVC and PV stay in the cluster with the data intact for a soak period — deleting them for real (and letting JuiceFS GC reclaim the S3 space) is a separate, later step.

## Verification after merge

- pod on `aetf-arch-homelab`, bound to the NodePV-backed PVC
- egress still `45.77.144.92` from inside its netns, inbound `:60011` still up
- hath logs: clean start, passing speed test, no `FAIL_*`
- over the following days, `works-unlimited-code-jfs` `DataTransfer-Out-Bytes` back to the ~0-1GB/day baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)