### PR TITLE
fix(dav): raise dufs cpu/memory limits to fix gateway timeouts

### DIFF
--- a/src/dav/index.ts
+++ b/src/dav/index.ts
@@ -43,8 +43,14 @@ export class Dufs extends pulumi.ComponentResource<DufsArgs> {
                 name,
                 image: versions.image.dufs,
                 resources: {
-                    requests: { cpu: "10m", memory: "8Mi" },
-                    limits: { cpu: "10m", memory: "8Mi" },
+                    // dufs terminates TLS itself, and a handshake needs far more
+                    // than the 1ms/100ms slice a 10m cap allows: with cpu limit ==
+                    // request the container sat at 100% throttled periods and even
+                    // the TLS handshake took ~8s, blowing past the gateway timeout.
+                    // Page cache from serving files counts against the memory limit
+                    // too, so 8Mi left no headroom.
+                    requests: { cpu: "10m", memory: "32Mi" },
+                    limits: { cpu: "500m", memory: "128Mi" },
                 },
                 ports: {
                     https: this.port,


### PR DESCRIPTION
## Problem

WebDAV at `dav.unlimited-code.works` was unusable: basic auth prompted and succeeded, then the browser got a gateway error.

Traefik was timing out on the backend:

```
"GET / HTTP/2.0" 401 ...  22ms                                  <- auth prompt
"GET / HTTP/2.0" 504 ... "https://10.42.0.6:5000" 10145ms       <- authed, backend timeout
```

## Root cause

dufs was pinned at `cpu request == limit == 10m`, i.e. a 1ms slice per 100ms CFS period. Since dufs terminates TLS itself, every connection needs an ECDHE handshake under that cap.

Measured on the old pod (direct port-forward, bypassing Traefik):

```
code=200 connect=0.0003 tls=7.90 total=62.40
```

The request was *correct* (200), just 60s slow. Prometheus confirmed `container_cpu_cfs_throttled_periods_total / periods_total = 1.0` — 100% of periods throttled, while actual usage was only 3.3m, well under the 10m cap. Classic "quota too small, one burst gets you parked for 99ms".

Memory was equally tight: page cache from serving files is charged to the cgroup, so the 8Mi limit sat at ~5.8Mi working set (5.3Mi of it cache) with no headroom — `kubectl exec` into the pod was OOM-killed.

`dav` was the only workload in the repo with CPU request == limit; everything else is burstable (e.g. k8s-dashboard 15m/100m).

## Fix

Give it a burstable envelope: requests `10m`/`32Mi`, limits `500m`/`128Mi`.

## Verification

Applied as a temporary `kubectl set resources` patch and measured:

| | before | after |
|---|---|---|
| TLS handshake | 7.90s | 0.30s |
| `GET /` total | 62.40s | 0.43s |
| throttled period ratio | 1.0 | 0 |
| cgroup QoS | `kubepods.slice` | `kubepods-burstable.slice` |

Real WebDAV traffic now serves PROPFIND in 110-200ms each, with CPU at 3.9m and 0 throttled periods — nowhere near the new limits. `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)