### PR TITLE
fix(immich,juicefs): stop the immich-server / mount pod restart churn

### DIFF
--- a/src/immich/index.ts
+++ b/src/immich/index.ts
@@ -121,20 +121,40 @@ export class Immich extends pulumi.ComponentResource<ImmichArgs> {
                                 main: {
                                     resources: {
                                         requests: { cpu: "1", memory: "1Gi" },
-                                        // ffmpeg tonemap transcoding pushes past 2Gi and gets OOMKilled
-                                        limits: { cpu: "1.5", memory: "3Gi" },
+                                        // ffmpeg tonemap transcoding pushes past 2Gi and gets OOMKilled.
+                                        // 3Gi was still not enough either: RSS peaked at 2.97Gi and the
+                                        // cgroup recorded oom_group_kill 12. At 1.5 cores the container
+                                        // was throttled on 89-94% of its CFS periods, which starves the
+                                        // node event loop and makes the liveness probe time out.
+                                        limits: { cpu: "2.5", memory: "4Gi" },
                                     },
+                                    // /api/server/ping answers in 0.09ms when idle and only times out
+                                    // while the job queue saturates the event loop, so liveness needs to
+                                    // tolerate a slow reply rather than restart the container. Readiness
+                                    // stays brisk on purpose: shedding traffic while overloaded is the
+                                    // correct response, and it does not restart anything.
                                     probes: {
                                         liveness: {
                                             spec: {
                                                 initialDelaySeconds: 60,
-                                                failureThreshold: 5,
+                                                periodSeconds: 30,
+                                                timeoutSeconds: 10,
+                                                failureThreshold: 6,
                                             },
                                         },
                                         readiness: {
                                             spec: {
                                                 initialDelaySeconds: 60,
-                                                failureThreshold: 5,
+                                                periodSeconds: 10,
+                                                timeoutSeconds: 5,
+                                                failureThreshold: 3,
+                                            },
+                                        },
+                                        startup: {
+                                            spec: {
+                                                periodSeconds: 10,
+                                                timeoutSeconds: 10,
+                                                failureThreshold: 30,
                                             },
                                         },
                                     },

--- a/src/juicefs.ts
+++ b/src/juicefs.ts
@@ -105,7 +105,43 @@ export class JuiceFs extends pulumi.ComponentResource<JuiceFs> {
                     // Use a new Priorityclass for Mount Pod to not preempt other pods.
                     // See: https://juicefs.com/docs/csi/guide/resource-optimization#set-non-preempting-priorityclass-for-mount-pod
                     mountPodNonPreempting: true,
-                }
+                },
+                // Mount pod tuning has to go through the CSI global config rather than
+                // the StorageClass below: StorageClass parameters are immutable, and
+                // existing PVs freeze the juicefs/mount-* parameters into their
+                // spec.csi.volumeAttributes at provision time, so editing the
+                // StorageClass never reaches volumes that are already provisioned.
+                // See: https://juicefs.com/docs/csi/guide/configurations
+                globalConfig: {
+                    mountPodPatch: [
+                        {
+                            // 512Mi sits below juicefs' own footprint: the default
+                            // --buffer-size alone is 300MiB, before the Go heap and
+                            // metadata cache. All four mount pods peaked at 437-522Mi
+                            // and immich's got OOM killed 25 times over 35h. It never
+                            // showed up as OOMKilled because the kernel reaps the
+                            // juicefs child rather than the mount.juicefs watchdog,
+                            // which then exits 2, so the container reports Error.
+                            resources: {
+                                requests: {
+                                    cpu: '100m',
+                                    memory: '256Mi',
+                                },
+                                limits: {
+                                    cpu: '1',
+                                    memory: '1Gi',
+                                }
+                            },
+                            mountOptions: [
+                                // cache-dir is a 49GiB disk but cache-size was never
+                                // set, so juicefs assumed its 100GiB default and ran
+                                // permanently against the free-space-ratio floor,
+                                // thrashing the cache into extra S3 GETs.
+                                'cache-size=30720', // MiB, i.e. 30GiB
+                            ],
+                        }
+                    ],
+                },
             }
         }, opts);
 


### PR DESCRIPTION
## What

immich-server restarted 95 times in 16 days and its juicefs mount pod 25 times in 35 hours. They looked like a feedback loop; they are not. Two independent failures, both caused by limits that were too tight.

## Root cause

**The two are not causally linked.** The mount pod restarted alone at 00:00, 09:25, 09:56 and 10:28 with no immich restart, and immich restarted alone at 08:54, 08:56 and 11:57 with no mount restart. JuiceFS CSI's fd-handover recovery (`JFS_SUPER_COMM`) keeps the mountpoint alive across a mount process restart — the `FUSE: interrupt request` flood in the logs *is* that handover cancelling in-flight requests, so it is a symptom, not a cause.

**juicefs mount pod** — OOM killed against its 512Mi limit. Pod-level cgroup `oom_kill 25` matches `restartCount 25` exactly, with `memory.peak` 522Mi over a 512Mi `memory.max`. It never appeared as `OOMKilled` because the kernel reaps the `juicefs` child rather than the `mount.juicefs` watchdog at pid 1, which then exits 2 and is reported as `Error`. 512Mi is too small for all of them — juicefs' default `--buffer-size` alone is 300MiB, and the other three mount pods peaked at 437–460Mi. immich was just the only one busy enough to cross.

**immich-server** — throttled on 89–94% of CFS periods at 1.5 cores (usage pinned at 1.48), with RSS peaking at 2.97Gi against the 3Gi limit and `oom_group_kill 12`. A starved Node event loop cannot answer `/api/server/ping` within the probe's **1s default timeout**, so liveness SIGTERMed it while nothing was actually wedged — that endpoint answers in 0.09ms when idle.

## Changes

- `src/juicefs.ts` — mount pod memory 512Mi → 1Gi (requests 64Mi → 256Mi), plus `cache-size=30720`, which was never set: the cache disk is 49GiB but juicefs assumed its 100GiB default and ran permanently against the `free-space-ratio` floor, re-fetching evicted blocks from S3.
- `src/immich/index.ts` — limits cpu 1.5 → 2.5, memory 3Gi → 4Gi; liveness tolerance ~50s → ~3min with an explicit `timeoutSeconds`. Readiness stays brisk on purpose (shedding traffic while overloaded is correct and restarts nothing; it was previously identical to liveness and so added nothing).

Mount pod tuning goes through the CSI global config rather than the StorageClass: StorageClass parameters are immutable, and existing PVs freeze `juicefs/mount-*` into `spec.csi.volumeAttributes` at provision time, so a StorageClass edit would never reach already-provisioned volumes. Verified against driver v0.32.0 that patch `resources` fully overrides those attributes and patch `mountOptions` merge per-key with the patch winning, so `cache-dir` / `free-space-ratio` survive.

## After merge — manual step required

`mountPodPatch` does **not** apply to existing mount pods. Once deployed:

```sh
kubectl delete pod -n kube-system -l app.kubernetes.io/name=juicefs-mount
```

fd-handover makes this near-transparent to the applications.

## Known trade-off

Memory *limits* on the 8GiB vps node go from 128% to ~163% overcommit. Requests stay healthy (50% → 59%). The lever for reducing actual demand is immich's job concurrency, which is being tuned separately in the admin UI.

## Verification

- mount pod pod-cgroup `memory.events` shows `oom_kill 0` and `memory.peak` < `memory.max`
- `Adjusted cache capacity based on freeratio` no longer appears in mount pod logs; cache disk drops ~82% → ~66%
- `rate(container_cpu_cfs_throttled_periods_total{namespace="immich",container="main"}[5m]) / rate(container_cpu_cfs_periods_total{...}[5m])` falls well below the current 0.89–0.94
- restart counts flat over 24–48h

🤖 Generated with [Claude Code](https://claude.com/claude-code)