### PR TITLE
fix(serving): pin traefik to the vps, next to where traffic arrives

### DIFF
--- a/src/serving/traefik.ts
+++ b/src/serving/traefik.ts
@@ -58,9 +58,22 @@ export class Traefik extends pulumi.ComponentResource<TraefikArgs> {
             namespace,
             chart: "traefik",
             values: {
+                // The public LoadBalancer only ever lands on the VPS (its
+                // service carries lbpool=internet, and that label is only on
+                // AetfArchVPS), so every request from the internet enters
+                // there. Leaving traefik unpinned let the scheduler park it on
+                // the homelab, which made all of that traffic take an extra
+                // ~84ms hop across the inter-node link just to reach the proxy
+                // -- before it even started talking to a backend. Pin it to the
+                // node the traffic already arrives on.
+                nodeSelector: args.base.nodes.AetfArchVPS.hostnameSelectorLabels,
                 resources: {
                     requests: { cpu: "10m", memory: "128Mi" },
-                    limits: { cpu: "50m", memory: "256Mi" }
+                    // 50m was enough to already show ~2% CFS throttling while
+                    // idle on the roomy homelab node; the VPS is the busier box
+                    // and traefik terminates TLS for every site, so give it
+                    // headroom to burst rather than getting parked mid-handshake.
+                    limits: { cpu: "500m", memory: "256Mi" }
                 },
                 providers: {
                     kubernetesGateway: {


### PR DESCRIPTION
Follow-up to #176. While diagnosing why WebDAV listings crawl in Finder, it turned out traefik is running on the homelab **by accident**.

## Finding

The public LoadBalancer only ever lands on the vps — traefik's service carries `svccontroller.k3s.cattle.io/lbpool=internet`, and that label is only on `AetfArchVPS` (`src/base-cluster/nodes.ts`). But traefik itself has **no placement constraint anywhere**:

- `src/serving/traefik.ts`: no `nodeSelector` / `affinity` / `tolerations` in the chart values
- live Deployment: all of them `None`, `hostNetwork` unset
- stateless: volumes are just `data`/`tmp` (emptyDir) + `tls` (secret) + serviceaccount — no PVC, no hostPath
- 26 commits touching `traefik.ts`, none about node placement

The vps rebooted on 2026-07-26; traefik came back on the homelab (pod dates from 08-08) and stayed.

## Impact

Every request from the internet pays an ~84ms inter-node hop before the proxy even looks at the route. For a backend that also lives on the vps, the link is crossed twice:

```
svclb(vps) → traefik(homelab) [WAN] → authelia(homelab) local → dufs(vps) [WAN]
```

That is what makes Finder's WebDAV listing crawl: it issues one PROPFIND per file plus a matching `._` AppleDouble probe, all sequential, each paying the round trip.

## Trade-off

Backends by node:

| on vps (8 routes) | on homelab (5 routes) |
|---|---|
| dav, nginx (5 hostnames), immich, spoolman, syncthing | authelia, grafana, splitpro, syncthing-nas, jellyfin |

Pinning traefik to the vps removes the unconditional `svclb→traefik` hop for **all** traffic, and removes the backend hop for the 8 vps-backed routes (including the main sites, photos and dav). The 5 homelab-backed routes gain a hop in exchange.

Colocating authelia would be the real optimum — its ForwardAuth is on every protected request — but it was deliberately moved off the vps in July because argon2id got CPU-throttled there, so that decision is left alone.

## Also: cpu limit 50m → 500m

traefik was already showing ~2% throttled CFS periods while **idle** on the roomy homelab node (2.8m used against a 50m limit). It terminates TLS for every site, the vps is the busier box, and a proxy parked mid-handshake is precisely the failure that just took dav down in #176.

## Review notes

- No local typecheck was run: the repo has no `tsconfig.json` and typescript isn't a dependency (it runs on `tsx`), so `pulumi preview` is the real gate here.
- Worth eyeballing in the preview output that `nodeSelector` renders as a concrete `kubernetes.io/hostname: aetf-arch-vps` rather than an unresolved value — `hostnameSelectorLabels` returns Outputs, and this is the first time it's passed into Helm chart values (existing uses are `src/splitpro/index.ts:198,331`, which are k8s CRs).
- Merging will restart traefik, i.e. a brief blip on every route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)