### PR TITLE
fix(juicefs): move the block cache onto the grown root disk

### DIFF
--- a/src/juicefs.ts
+++ b/src/juicefs.ts
@@ -137,12 +137,43 @@ export class JuiceFs extends pulumi.ComponentResource<JuiceFs> {
                                     memory: '1Gi',
                                 }
                             },
+                            // Patch mountOptions replace, rather than add to, any
+                            // option of the same name coming from the PV, so these
+                            // three override what the StorageClass below hands out,
+                            // and they do so for already-provisioned volumes too.
                             mountOptions: [
-                                // cache-dir is a 49GiB disk but cache-size was never
-                                // set, so juicefs assumed its 100GiB default and ran
-                                // permanently against the free-space-ratio floor,
-                                // thrashing the cache into extra S3 GETs.
-                                'cache-size=30720', // MiB, i.e. 30GiB
+                                // The cache used to live on /mnt/storage, a 49GiB
+                                // block volume it shares with the local-path PVCs and
+                                // the webroot. The root disk has since been grown from
+                                // 56GiB to 156GiB and now has more free space than that
+                                // volume has in total, so the cache moves there and the
+                                // block volume gets its ~30GiB back.
+                                //
+                                // One directory, deliberately. cache-size is the total
+                                // across all cache dirs and juicefs splits it evenly
+                                // between them (dirCacheSize = CacheSize / len(dirs)),
+                                // so keeping /mnt/storage as a second directory would
+                                // have capped the whole cache at twice what the small
+                                // volume can hold - less than the root disk gives on
+                                // its own.
+                                'cache-dir=/var/lib/jfs-cache',
+                                // Close to the most this filesystem can give. juicefs
+                                // measures free space as statfs Bavail, which excludes
+                                // ext4's reserved blocks, so the 153.2GiB filesystem
+                                // offers 105.2GiB; a 70GiB cache leaves 23.0% free
+                                // against the 20% floor below. The ceiling at that
+                                // ratio is ~74.6GiB, and going past it would only put
+                                // juicefs permanently against the floor again, which
+                                // is the state #178 fixed. The previous 30GiB was
+                                // simply what the old volume could hold.
+                                'cache-size=71680', // MiB, i.e. 70GiB
+                                // The cache now shares a filesystem with the kubelet,
+                                // whose nodefs DiskPressure eviction threshold is 10%
+                                // free. Leaving juicefs' floor at the default 0.1 would
+                                // put the two at exactly the same point; 0.2 makes
+                                // juicefs stop growing the cache well before the
+                                // kubelet starts evicting pods.
+                                'free-space-ratio=0.2',
                             ],
                         }
                     ],
@@ -185,6 +216,13 @@ export class JuiceFs extends pulumi.ComponentResource<JuiceFs> {
                     //"no-bgjob", // disable background jobs
 
                     "upload-delay=10s", // wait 10s before upload, such that small write and delete is completely served from local cache
+
+                    // Dead values, both overridden by the mountPodPatch above, which
+                    // is where the cache is actually configured. They are left here
+                    // rather than corrected because mountOptions are part of the
+                    // immutable StorageClass spec: editing them would replace the
+                    // StorageClass without reaching any volume already provisioned,
+                    // since a PV copies mountOptions from the class at creation.
                     "free-space-ratio=0.1",
                     "cache-dir=/mnt/storage/jfs-cache",
                 ]


### PR DESCRIPTION
Follow-up to #178 (cache capped at 30GiB) and #182 (mount pod metrics). Depends on the vps root disk having been grown, which is already done: `/dev/vda` had 100GiB of never-partitioned space after `vda2`, so `vda2` went 56GiB → 156GiB and `/` is now 154G at 29% instead of 55G at 80%.

## What

Moves the juicefs block cache off `/mnt/storage` (a 49GiB block volume it shares with the local-path PVCs and the webroot) onto the root disk, and raises the cap from 30GiB to 70GiB.

## Why one directory and not two

Adding `/var/lib/jfs-cache` as a *second* cache dir was the obvious move and is the worst of the three options:

- `cache-size` is the total across all cache dirs and juicefs divides it **evenly** between them regardless of how big each one is — `dirCacheSize := int64(config.CacheSize) / int64(len(dirs))` in `pkg/chunk/disk_cache.go`. The 49GiB volume would therefore have capped the entire cache at roughly twice what it alone can hold, which is *less* than the root disk gives on its own.
- It would also have cost about half the warm cache immediately. The cache manager routes keys through a consistent hash ring over the cache stores (`consistenthash.New(100, murmur3.Sum32)`, store identity persisted in `<dir>/<uuid>/.lock`), so going from one store to two remaps roughly half the keyspace; those blocks stay on disk but stop being addressable and get re-fetched from S3.

With a single directory the ring has one member and every key lands on it, so the existing 30GiB can just be rsynced to the new path and stays warm.

## free-space-ratio 0.1 → 0.2, and why 70GiB is the right number

The cache now shares a filesystem with the kubelet, whose `nodefs.available` DiskPressure eviction threshold is also 10% free. Left at the default the two would trigger at exactly the same point, so a full disk would start evicting pods rather than merely starving the cache. juicefs takes the same view of cache dirs on the root volume — `inRootVolume` in `pkg/chunk/utils_unix.go` exists to force the ratio to 0.2 in exactly this situation, though only from its broken-device path, and it compares `st_dev` against `/`, which inside the mount pod is the container overlay. So the setting has to be explicit here.

Sizing, in the units juicefs actually uses. `getDiskUsage` reads `statfs.Bavail`, which **excludes** ext4's reserved blocks, and the runtime eviction check is `available / total < free-space-ratio`:

- `/` is 153.2GiB total with 105.2GiB `Bavail` (6.8GiB, 4.4%, is reserved for root)
- a 70GiB cache leaves 35.2GiB available, a ratio of 23.0% against a 20.0% floor
- the static cap `(1 - ratio) * total` = 122.6GiB does not bind here, so `cache-size` is what governs

That is only ~4.6GiB of slack for everything else on `/` to grow before juicefs starts evicting to defend the ratio. Reclaiming most of the ext4 reserve (see rollout) takes that to ~9.9GiB and makes 70GiB comfortable rather than snug. The hard ceiling at ratio 0.2 is ~74.6GiB, so there is no useful room above 70 — going bigger means either dropping the ratio, which re-couples juicefs' floor to kubelet's eviction line, or a bigger dedicated disk.

## Why the CSI global config again

Same reason as #178. Patch `mountOptions` *replace* same-key options coming from the PV (`applyConfigPatch` builds `patchOptionsMap` keyed on the part before `=`), so `cache-dir`, `cache-size` and `free-space-ratio` all reach volumes provisioned years ago. Editing the StorageClass would not: `mountOptions` are part of its immutable spec, and a PV copies them at creation. The now-dead values are left in the StorageClass with a comment saying so.

## Rollout

Not a plain merge — the cache has to be pre-warmed first, and the mount pods do not pick up `mountPodPatch` changes on their own.

1. **Before merging**, on `aetf-arch-vps`, reclaim the ext4 reserve and pre-warm:
   ```
   sudo tune2fs -m 1 /dev/vda2
   sudo mkdir -p /var/lib/jfs-cache
   sudo rsync -aH --info=progress2 /mnt/storage/jfs-cache/ /var/lib/jfs-cache/
   ```
   `tune2fs -m 1` is online, instant and reversible; 5% reserved blocks is a default meant for much smaller filesystems and costs 6.8GiB here, which is most of the headroom this change needs. The rsync moves ~30GiB between two local disks. Concurrent writes during the copy are safe: `verify-cache-checksum` defaults to `extend`, so a half-copied block is checksum-rejected rather than served.

2. Merge, let CI deploy, then force the mount pods to be rebuilt with the new options:
   ```
   kubectl delete pod -n kube-system -l app.kubernetes.io/name=juicefs-mount
   ```
   The CSI fd handoff (`JFS_SUPER_COMM`) keeps the mount points alive across this.

3. Verify the pre-warm worked: `juicefs_blockcache_bytes` should come back at ~31.7e9 immediately rather than climbing from 0. Also confirm no `Adjusted cache capacity based on freeratio` line in the mount pod logs — that would mean the ratio is binding rather than `cache-size`.

4. After a day, reclaim the old directory (juicefs will not):
   ```
   sudo rm -rf /mnt/storage/jfs-cache/e8ef31db-4690-4a19-95f2-fb4d77435054
   ```

## Note for dashboards

All five mount pods share this one cache directory (`storageClassShareMount: false` gives each PVC its own mount pod, but they all point at the same filesystem and the same cache dir, each enforcing `cache-size` independently). So `juicefs_blockcache_bytes` and `_blocks` read almost identically on all five and must be aggregated with `max`, not `sum`; the hit/miss and object-request counters are per-pod traffic and do want `sum`.

Draft until #182's PodMonitor has collected a day or two of clean baseline, so the before/after is actually measurable — the cache is the S3 bill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)