### PR TITLE
fix(juicefs): stop the mount pods OOMing without spending node memory

### DIFF
--- a/src/juicefs.ts
+++ b/src/juicefs.ts
@@ -120,13 +120,24 @@ export class JuiceFs extends pulumi.ComponentResource<JuiceFs> {
                 globalConfig: {
                     mountPodPatch: [
                         {
-                            // 512Mi sits below juicefs' own footprint: the default
+                            // 512Mi sat below juicefs' own footprint: the default
                             // --buffer-size alone is 300MiB, before the Go heap and
                             // metadata cache. All four mount pods peaked at 437-522Mi
                             // and immich's got OOM killed 25 times over 35h. It never
                             // showed up as OOMKilled because the kernel reaps the
                             // juicefs child rather than the mount.juicefs watchdog,
                             // which then exits 2, so the container reports Error.
+                            //
+                            // 1Gi turned out not to be enough either: immich's mount
+                            // pod took another 6 OOM kills in the following day, peaking
+                            // at 1037Mi. The limit deliberately stays at 1Gi anyway -
+                            // see the env and buffer-size below. The vps has 7.7Gi of
+                            // RAM and dipped to 0.74Gi available at its worst point in
+                            // that same day, with immich-server (2912Mi peak),
+                            // immich-db (1025Mi) and this pod all peaking together, so
+                            // raising the ceiling would spend memory the node does not
+                            // have and trade a mount pod restart for a node-level OOM
+                            // that picks its victim at random.
                             resources: {
                                 requests: {
                                     cpu: '100m',
@@ -137,10 +148,27 @@ export class JuiceFs extends pulumi.ComponentResource<JuiceFs> {
                                     memory: '1Gi',
                                 }
                             },
+                            // juicefs is a Go program and nothing told the runtime about
+                            // the cgroup limit above, so the heap grew on the default
+                            // GOGC=100 schedule until the kernel killed it. GOMEMLIMIT
+                            // is the fix for that: the GC treats it as a soft ceiling
+                            // and collects harder as it approaches, which costs CPU
+                            // rather than the process. 800MiB leaves ~220MiB of the
+                            // limit for what the Go runtime does not account for.
+                            env: [
+                                {
+                                    name: 'GOMEMLIMIT',
+                                    value: '800MiB',
+                                },
+                            ],
                             // Patch mountOptions replace, rather than add to, any
-                            // option of the same name coming from the PV, so these
-                            // three override what the StorageClass below hands out,
-                            // and they do so for already-provisioned volumes too.
+                            // option of the same name coming from the PV, so the ones
+                            // that collide override what the StorageClass below hands
+                            // out, for already-provisioned volumes too. Note this list
+                            // is also replaced wholesale by any later patch entry that
+                            // sets mountOptions - MountPodPatch.merge() assigns rather
+                            // than appends - so a second, pvcSelector-scoped entry would
+                            // have to repeat all of this, not just its own additions.
                             mountOptions: [
                                 // The cache used to live on /mnt/storage, a 49GiB
                                 // block volume it shares with the local-path PVCs and
@@ -174,6 +202,14 @@ export class JuiceFs extends pulumi.ComponentResource<JuiceFs> {
                                 // juicefs stop growing the cache well before the
                                 // kubelet starts evicting pods.
                                 'free-space-ratio=0.2',
+                                // The single largest allocation juicefs makes, and the
+                                // one thing that can be given back without buying node
+                                // memory. Read/write buffering, 300MiB by default; the
+                                // four quiet volumes never come close to using it and
+                                // immich is bounded by S3 bandwidth rather than by this
+                                // pool. Bare numbers are MiB here, same as cache-size
+                                // above - both go through utils.ParseBytes(_, _, 'M').
+                                'buffer-size=200',
                             ],
                         }
                     ],


### PR DESCRIPTION
Follow-up to #178, which raised the mount pod memory limit from 512Mi to 1Gi. That was not enough: immich's mount pod took another **6 OOM kills in the 24h since**, peaking at 1037Mi against the 1Gi limit. The pod cgroup's `oom_kill` counter matches its `restartCount` exactly, and it still surfaces as `Error` rather than `OOMKilled` for the reason #178 documented — the kernel reaps the `juicefs` child, and the `mount.juicefs` watchdog at pid 1 then exits 2.

5 of those 6 landed at 15:44–16:44 UTC, in the middle of an ordinary workday, not during the nightly integrity scan. 1Gi is simply not enough for this volume.

## Why not just raise the limit again

The vps cannot afford it. It has 7.7Gi of RAM, and over the same 24h `node_memory_MemAvailable_bytes` bottomed out at **0.74Gi**, with the three big consumers peaking together:

| pod | peak | limit |
|---|---|---|
| immich-server | 2912Mi | 4096Mi |
| juicefs mount (immich) | 1037Mi | 1024Mi |
| immich-db | 1025Mi | 1024Mi |

Adding a gigabyte of ceiling spends memory the node does not have. It would also trade a mount pod restart — which the CSI fd handoff (`JFS_SUPER_COMM`) makes nearly invisible to the application — for a node-level OOM that picks its victim at random.

## Making juicefs want less instead

Two changes, neither of which costs the node anything:

**`GOMEMLIMIT=800MiB`.** juicefs is a Go program and nothing was telling the runtime about the cgroup limit, so the heap grew on the default `GOGC=100` schedule straight through it — the kernel, not the runtime, was enforcing the ceiling. This is the textbook Go-in-a-container failure. With `GOMEMLIMIT` the GC treats the value as a soft limit and collects harder as it approaches, spending CPU instead of the process. 800MiB leaves ~220MiB of the 1Gi for what the Go runtime does not account for.

**`buffer-size=200`** (default 300MiB). The single largest allocation juicefs makes and the easiest to give back: the four quiet volumes never come close to using it, and immich's throughput is bounded by S3 bandwidth rather than by this pool. Bare numbers are MiB, same as `cache-size` — both go through `utils.ParseBytes(_, _, 'M')` in `cmd/mount.go`.

Applied globally rather than through a `pvcSelector` entry scoped to immich, deliberately. All five mount pods share the same 1Gi limit, so the `GOMEMLIMIT` value is right for all of them, and the quiet ones peak at 437–460Mi so neither change binds for them. A scoped entry would also have to repeat the entire `mountOptions` list, because `MountPodPatch.merge()` assigns these lists rather than appending — a second entry setting `mountOptions` silently drops #183's cache configuration instead of adding to it. That trap is now recorded in a comment next to the list.

## If it is not enough

The failure mode changes from being killed to burning CPU on GC, which is visible in #184's dashboards and recoverable, unlike the current one. That is the point at which a real limit increase would be justified, with data behind it.

Worth noting that immich is expected to move off juicefs and back to the homelab node eventually, at which point this entire tuning problem goes away rather than needing to be carried forward. This change is scoped as short-term stabilisation on purpose.

## Rollout

`mountPodPatch` changes do not reach existing mount pods, so after CI deploys:

```
kubectl delete pod -n kube-system -l app.kubernetes.io/name=juicefs-mount
```

Then verify `GOMEMLIMIT` is in the new pods' env and `buffer-size=200` in their mount command, and watch the immich mount pod's `container_memory_working_set_bytes` and restart count over the next day. The cache does not need re-warming: it lives on the host at `/var/lib/jfs-cache` and survives pod recreation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)