### PR TITLE
fix(splitpro): make OIDC users findable by email

### DIFF
--- a/src/serving/authelia-static/01-oidc.yaml
+++ b/src/serving/authelia-static/01-oidc.yaml
@@ -1,5 +1,20 @@
 identity_providers:
   oidc:
+    claims_policies:
+      # Authelia only puts the standard claims in the ID token; everything the
+      # `email`/`profile` scopes grant is served from the userinfo endpoint
+      # instead. That is fine for clients that call it, but SplitPro's NextAuth
+      # provider sets `idToken: true`, and NextAuth v4 then builds the profile
+      # purely out of the ID token claims and never calls userinfo -- so its
+      # users end up with a null email, which is the only key it has for
+      # matching people to each other.
+      splitpro:
+        id_token:
+          - email
+          - email_verified
+          # SplitPro seeds the display name from this; without it new users are
+          # named after the local part of their email address.
+          - name
     clients:
       - client_name: Immich OAuth Connection
         client_id: {{ env "CONFIG_EXTRA_OIDC_CLIENTS_IMMICH_ID_FILE" | secret | mindent 8 "|" | msquote }}
@@ -59,6 +74,7 @@ identity_providers:
         client_secret: {{ env "CONFIG_EXTRA_OIDC_CLIENTS_SPLITPRO_SECRET_FILE" | secret | mindent 8 "|" | msquote }}
         public: false
         authorization_policy: splitpro
+        claims_policy: 'splitpro'
         # No PKCE, unlike the other clients here: SplitPro builds its NextAuth
         # provider without `checks: ['pkce']` (src/server/auth.ts), and NextAuth
         # v4 only does `state` by default, so it never sends a code_challenge.

--- a/src/splitpro/index.ts
+++ b/src/splitpro/index.ts
@@ -127,6 +127,21 @@ export class Splitpro extends pulumi.ComponentResource<SplitproArgs> {
                     'OIDC_CLIENT_ID': args.authSecret.asEnvValue('oidc_client_id'),
                     'OIDC_CLIENT_SECRET': args.authSecret.asEnvValue('oidc_client_secret'),
                     'OIDC_WELL_KNOWN_URL': pulumi.interpolate`https://${args.authSubdomain}.${args.domain}/.well-known/openid-configuration`,
+                    // Adding someone by email creates a placeholder user row for
+                    // them, and that is the *only* way to reach a person you
+                    // have no shared expenses with -- there is no user search.
+                    // Without email linking, that person's first OIDC login
+                    // fails with OAuthAccountNotLinked instead of taking over
+                    // the placeholder, so they would need a second account to
+                    // get in and would still be invisible to whoever invited
+                    // them. It is "dangerous" only when the identity provider
+                    // lets users pick unverified emails; Authelia is the sole
+                    // provider here and its addresses come from users.yaml.
+                    //
+                    // Note the value is never parsed: env.ts does
+                    // `Boolean(process.env.…)`, so 'false' would enable it too.
+                    // Unset the variable to turn it off.
+                    'OIDC_ALLOW_DANGEROUS_EMAIL_LINKING': 'true',
 
                     // Authelia is the only way in, and deliberately the *only*
                     // way: no EMAIL_SERVER_HOST means NextAuth never registers


### PR DESCRIPTION
Two users had both signed in successfully but could not add each other to a group — neither name nor email search found anything.

## Cause

SplitPro has no user directory. The picker in *add members* is `user.getFriends`, which lists only people you already share a balance with; the one way to reach anyone else is the email box, which does an exact `findUnique({ email })`. Every account created through Authelia had `email = NULL`, so that lookup never matched and each attempt quietly created a **new placeholder user** with that address. The database had five users for three people.

The email was missing because Authelia serves `email`/`name` from the userinfo endpoint, not the ID token, while SplitPro's NextAuth provider sets `idToken: true` — NextAuth v4 then builds the profile purely from ID token claims and never calls userinfo. Decoding a stored `id_token` confirms it: `sub`, `aud`, `amr`, `iss` and nothing else.

## Changes

- **Authelia**: a `claims_policies.splitpro` adding `email`, `email_verified` and `name` to the ID token, attached to the SplitPro client via `claims_policy`.
- **SplitPro**: `OIDC_ALLOW_DANGEROUS_EMAIL_LINKING=true`, so an invitee's first login takes over the placeholder row that was created for them instead of failing with `OAuthAccountNotLinked`. Safe here because Authelia is the only provider and addresses come from `users.yaml`.

## Verification

- `authelia validate-config` against the candidate config inside the running pod: parses and loads, with the same single pre-existing warning (Grafana's `offline_access` scope) as the live config — no new errors.
- `pulumi preview`: 2 updates + 1 replace (the config map), all in the two intended resources.

Existing rows are not backfilled by this — NextAuth only reads the profile at `createUser` — so the duplicate users are cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)